### PR TITLE
Feature/post

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:5173"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
         configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
     }
 
     // 게시글 세부 정보 수정
-    @PutMapping("{postId}")
+    @PatchMapping("{postId}")
     public ResponseEntity<String> updatePostApi(@PathVariable Long postId,
                                                 @AuthenticationPrincipal UserPrincipal userPrincipal,
                                                 @RequestBody PostUpdateRequestDto dto) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -1,0 +1,64 @@
+package io.github.junhyoung.nearbuy.post.controller;
+
+import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
+import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.request.PostDeleteRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
+import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
+import io.github.junhyoung.nearbuy.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/post")
+public class PostController {
+
+    private final PostService postService;
+
+    // 게시글 생성
+    @PostMapping
+    public ResponseEntity<String> createPostApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                @RequestBody PostCreateRequestDto dto) {
+        postService.createPost(userPrincipal.id(), dto);
+        return ResponseEntity.status(201).body("게시글 등록이 완료되었습니다.");
+    }
+
+    // 게시글 전체 조회
+    @GetMapping
+    public ResponseEntity<List<PostResponseDto>> readPostApi() {
+        List<PostResponseDto> postResponseDtos = postService.readPosts();
+        return ResponseEntity.status(200).body(postResponseDtos);
+    }
+
+    // 특정 게시글 상세 조회
+    @GetMapping("{postId}")
+    public ResponseEntity<PostDetailResponseDto> readPostDetailApi(@PathVariable Long postId) {
+        PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(postId);
+        return ResponseEntity.status(200).body(postDetailResponseDto);
+    }
+
+    // 게시글 세부 정보 수정
+    @PutMapping("{postId}")
+    public ResponseEntity<String> updatePostApi(@PathVariable Long postId,
+                                                @AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                @RequestBody PostUpdateRequestDto dto) {
+        postService.updatePost(postId, userPrincipal.id(), dto);
+        return ResponseEntity.status(200).body("게시글 수정이 완료되었습니다.");
+    }
+
+
+    // DELETE
+    @DeleteMapping("{postId}")
+    public ResponseEntity<String> deletePostApi(@PathVariable Long postId,
+                                                @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        postService.deletePost(postId, userPrincipal.id());
+        return ResponseEntity.status(200).body("게시글 삭제가 완료되었습니다.");
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostCreateRequestDto.java
@@ -1,0 +1,37 @@
+package io.github.junhyoung.nearbuy.post.dto.request;
+
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostCreateRequestDto {
+
+    private String title;
+
+    private String contents;
+
+    private Integer price;
+
+    private ProductCategory productCategory;
+
+    private String imageUrl;
+
+    public PostEntity toEntity(UserEntity userEntity) {
+        return PostEntity.builder()
+                .userEntity(userEntity)
+                .title(this.title)
+                .contents(this.contents)
+                .price(this.price)
+                .productCategory(this.productCategory)
+                .postStatus(PostStatus.ON_SALE)
+                .imageUrl(this.imageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostDeleteRequestDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostDeleteRequestDto.java
@@ -1,0 +1,15 @@
+package io.github.junhyoung.nearbuy.post.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostDeleteRequestDto {
+
+
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostUpdateRequestDto.java
@@ -1,0 +1,29 @@
+package io.github.junhyoung.nearbuy.post.dto.request;
+
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostUpdateRequestDto {
+
+    private String title;
+
+    private String contents;
+
+    private Integer price;
+
+    private ProductCategory productCategory;
+
+    private PostStatus postStatus;
+
+    private String imageUrl;
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
@@ -1,0 +1,46 @@
+package io.github.junhyoung.nearbuy.post.dto.response;
+
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostDetailResponseDto {
+
+
+    private Long authorId;
+
+    private Long postId;
+
+    private String authorNickname;
+
+    private String title;
+
+    private String contents;
+
+    private Integer price;
+
+    private ProductCategory productCategory;
+
+    private LocalDateTime createdAt;
+
+    private String imageUrl;
+
+    @Builder
+    public PostDetailResponseDto(PostEntity postEntity) {
+        this.postId = postEntity.getId();
+        this.authorId = postEntity.getUserEntity().getId();
+        this.authorNickname = postEntity.getUserEntity().getNickname();
+        this.title = postEntity.getTitle();
+        this.contents = postEntity.getContents();
+        this.price = postEntity.getPrice();
+        this.productCategory = postEntity.getProductCategory();
+        this.createdAt = postEntity.getCreatedAt();
+        this.imageUrl = postEntity.getImageUrl();
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
@@ -1,0 +1,40 @@
+package io.github.junhyoung.nearbuy.post.dto.response;
+
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostResponseDto {
+
+    private Long postId;
+
+    private String authorNickname;
+
+    private String title;
+
+    private Integer price;
+
+    private ProductCategory productCategory;
+
+    private LocalDateTime createdAt;
+
+    private String imageUrl;
+
+    @Builder
+    public PostResponseDto(PostEntity postEntity) {
+        this.postId = postEntity.getId();
+        this.authorNickname = postEntity.getUserEntity().getNickname();
+        this.title = postEntity.getTitle();
+        this.price = postEntity.getPrice();
+        this.productCategory = postEntity.getProductCategory();
+        this.createdAt = postEntity.getCreatedAt();
+        this.imageUrl = postEntity.getImageUrl();
+    }
+
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
@@ -1,16 +1,20 @@
 package io.github.junhyoung.nearbuy.post.entity;
 
 import io.github.junhyoung.nearbuy.global.entity.BaseEntity;
+import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
 import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
 import io.github.junhyoung.nearbuy.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class PostEntity extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,26 +28,49 @@ public class PostEntity extends BaseEntity {
     @Column(name = "title")
     private String title;
 
-    @Column(name = "content")
-    private String content;
+    @Column(name = "contents")
+    private String contents;
 
     @Column(name = "price")
     private Integer price;
 
+    @Column(name = "post_status")
+    @Enumerated(value = EnumType.STRING)
+    private PostStatus postStatus;
+
     @Column(name = "product_category")
+    @Enumerated(value = EnumType.STRING)
     private ProductCategory productCategory;
 
     @Column(name = "imageUrl")
     private String imageUrl;
 
     @Builder
-    public PostEntity(UserEntity userEntity, String title, String content, Integer price, ProductCategory productCategory, String imageUrl) {
+    public PostEntity(UserEntity userEntity, String title, String contents, Integer price, ProductCategory productCategory, PostStatus postStatus, String imageUrl) {
         this.userEntity = userEntity;
         this.title = title;
-        this.content = content;
+        this.contents = contents;
         this.price = price;
         this.productCategory = productCategory;
+        this.postStatus = postStatus;
         this.imageUrl = imageUrl;
+    }
+
+    //== 연관관계 편의 메서드 ==//
+    public void setUserEntity(UserEntity userEntity) {
+        this.userEntity = userEntity;   // 게시글 작성자 설정
+        userEntity.getPostEntityList().add(this);   // 사용자가 작성한 게시글에 현재 게시글 추가
+    }
+
+    //== 내부 메서드 ==//
+
+    public void updatePostDetail(PostUpdateRequestDto dto) {
+        this.title = dto.getTitle();
+        this.contents = dto.getContents();
+        this.postStatus = dto.getPostStatus();
+        this.price = dto.getPrice();
+        this.productCategory = dto.getProductCategory();
+        this.imageUrl = dto.getImageUrl();
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
@@ -1,0 +1,49 @@
+package io.github.junhyoung.nearbuy.post.entity;
+
+import io.github.junhyoung.nearbuy.global.entity.BaseEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostEntity extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "price")
+    private Integer price;
+
+    @Column(name = "product_category")
+    private ProductCategory productCategory;
+
+    @Column(name = "imageUrl")
+    private String imageUrl;
+
+    @Builder
+    public PostEntity(UserEntity userEntity, String title, String content, Integer price, ProductCategory productCategory, String imageUrl) {
+        this.userEntity = userEntity;
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.productCategory = productCategory;
+        this.imageUrl = imageUrl;
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
@@ -63,14 +63,25 @@ public class PostEntity extends BaseEntity {
     }
 
     //== 내부 메서드 ==//
-
     public void updatePostDetail(PostUpdateRequestDto dto) {
-        this.title = dto.getTitle();
-        this.contents = dto.getContents();
-        this.postStatus = dto.getPostStatus();
-        this.price = dto.getPrice();
-        this.productCategory = dto.getProductCategory();
-        this.imageUrl = dto.getImageUrl();
+        if (dto.getTitle() != null) {
+            this.title = dto.getTitle();
+        }
+        if (dto.getContents() != null) {
+            this.contents = dto.getContents();
+        }
+        if (dto.getPostStatus() != null) {
+            this.postStatus = dto.getPostStatus();
+        }
+        if (dto.getPrice() != null) {
+            this.price = dto.getPrice();
+        }
+        if (dto.getProductCategory() != null) {
+            this.productCategory = dto.getProductCategory();
+        }
+        if (dto.getImageUrl() != null) {
+            this.imageUrl = dto.getImageUrl();
+        }
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/enumerate/PostStatus.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/enumerate/PostStatus.java
@@ -1,0 +1,20 @@
+package io.github.junhyoung.nearbuy.post.entity.enumerate;
+
+import lombok.Getter;
+
+@Getter
+public enum PostStatus {
+    ON_SALE("판매중"),
+    RESERVED("예약중"),
+    SOLD_OUT("판매완료");
+
+    private final String description;
+
+    PostStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/enumerate/ProductCategory.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/enumerate/ProductCategory.java
@@ -1,0 +1,19 @@
+package io.github.junhyoung.nearbuy.post.entity.enumerate;
+
+import lombok.Getter;
+
+@Getter
+public enum ProductCategory {
+    DIGITAL_DEVICE("디지털기기"),
+    FURNITURE_INTERIOR("인테리어"),
+    CLOTHING("의류"),
+    HOME_APPLIANCES("가전"),
+    BEAUTY("뷰티"),
+    BOOKS("도서");
+
+    private final String description;
+
+    ProductCategory(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package io.github.junhyoung.nearbuy.post.repository;
+
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<PostEntity, Long> {
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -1,0 +1,85 @@
+package io.github.junhyoung.nearbuy.post.service;
+
+import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
+import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
+import io.github.junhyoung.nearbuy.post.repository.PostRepository;
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import io.github.junhyoung.nearbuy.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    // 게시글 생성
+    @Transactional
+    public void createPost(Long authorId, PostCreateRequestDto dto) {
+        UserEntity author = userRepository.findById(authorId)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
+
+        PostEntity postEntity = dto.toEntity(author);
+        postEntity.setUserEntity(author);
+
+        postRepository.save(postEntity);
+    }
+
+    // 게시글 전체 조회
+    public List<PostResponseDto> readPosts() {
+        List<PostEntity> posts = postRepository.findAll();
+
+        List<PostResponseDto> postResponseDtos = posts.stream()
+                .map((post) -> PostResponseDto.builder()
+                        .postEntity(post)
+                        .build()).collect(Collectors.toList());
+
+        return postResponseDtos;
+    }
+
+    // 게시글 세부 조회
+    public PostDetailResponseDto readPostDetail(Long postId) {
+        PostEntity postEntity = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));
+
+        return PostDetailResponseDto.builder()
+                .postEntity(postEntity)
+                .build();
+    }
+
+    // 게시글 세부 정보 수정
+    public void updatePost(Long postId, Long userId, PostUpdateRequestDto dto) {
+        PostEntity postEntity = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));
+        if (!postEntity.getUserEntity().getId().equals(userId)) {
+            throw new AccessDeniedException("게시글 수정은 작성자만 가능합니다.");
+        }
+        postEntity.updatePostDetail(dto);
+    }
+
+    // 게시글 삭제
+    public void deletePost(Long postId, Long userId) {
+        PostEntity postEntity = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));
+        if (!postEntity.getUserEntity().getId().equals(userId)) {
+            throw new AccessDeniedException("게시글 삭제는 작성자만 가능합니다.");
+        }
+        postRepository.delete(postEntity);
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -5,7 +5,6 @@ import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
-import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
 import io.github.junhyoung.nearbuy.post.repository.PostRepository;
 import io.github.junhyoung.nearbuy.user.entity.UserEntity;
 import io.github.junhyoung.nearbuy.user.repository.UserRepository;
@@ -63,6 +62,7 @@ public class PostService {
     }
 
     // 게시글 세부 정보 수정
+    @Transactional
     public void updatePost(Long postId, Long userId, PostUpdateRequestDto dto) {
         PostEntity postEntity = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));
@@ -73,6 +73,7 @@ public class PostService {
     }
 
     // 게시글 삭제
+    @Transactional
     public void deletePost(Long postId, Long userId) {
         PostEntity postEntity = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));

--- a/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
     // 유저 정보
     @GetMapping
     public UserResponseDto userMeApi(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        return userService.readUser(userPrincipal.username());
+        return userService.readUserByUsername(userPrincipal.username());
     }
 
     // 유저 수정 (자체 로그인 유저만)

--- a/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package io.github.junhyoung.nearbuy.user.entity;
 
 import io.github.junhyoung.nearbuy.global.entity.BaseEntity;
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
 import io.github.junhyoung.nearbuy.user.entity.enumerate.SocialProviderType;
 import io.github.junhyoung.nearbuy.user.entity.enumerate.UserRoleType;
 import io.github.junhyoung.nearbuy.user.dto.request.UserUpdateRequestDto;
@@ -10,6 +11,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user")
@@ -17,7 +21,11 @@ import lombok.NoArgsConstructor;
 public class UserEntity extends BaseEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
+
+    @OneToMany(mappedBy = "userEntity", fetch = FetchType.LAZY)
+    private List<PostEntity> postEntityList = new ArrayList<>();
 
     @Column(name="username", unique = true, nullable = false, updatable = false)
     private String username;

--- a/src/main/java/io/github/junhyoung/nearbuy/user/service/UserService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/service/UserService.java
@@ -78,7 +78,7 @@ public class UserService {
     /**
      * 현재 로그인한 유저의 정보를 조회
      */
-    public UserResponseDto readUser(String username) {
+    public UserResponseDto readUserByUsername(String username) {
         UserEntity entity = findUserByUsername(username);
         return new UserResponseDto(entity.getUsername(), entity.getIsSocial(), entity.getNickname(), entity.getEmail());
     }


### PR DESCRIPTION
## 📌 개요
중고거래 게시글(Post) 도메인을 추가하고, 게시글 생성, 조회, 수정, 삭제(CRUD) 등 핵심 API 기능을 구현합니다.

---
## 📋 작업 내용.

### 1. 게시글(Post) CRUD 기능 추가
- PostController: 게시글 CRUD API 엔드포인트 구현
- PostService: 게시글 생성, 전체/상세 조회, 수정, 삭제 비즈니스 로직 구현
- PostRepository: PostEntity의 영속성 관리를 위한 리포지토리 추가
- PostEntity: 게시글 도메인 엔티티 정의 (User와 연관관계 설정 포함)

### 2. 관련 DTOs (Request/Response) 추가
- User-Post 양방향 연관관계 설정
- UserEntity: 작성한 게시글 목록을 조회할 수 있도록 postEntityList 필드를 추가하여 양방향 관계 설정

### 3. 게시글 부분 업데이트 기능 구현 (PATCH)
- PostController: 게시글 수정 API를 PUT에서 PATCH로 변경하여, 클라이언트가 원하는 필드만 보낼 수 있도록 개선
- PostEntity: updatePostDetail 메서드에 if-null 체크 로직을 추가하여 부분 업데이트가 가능하도록 수정
- SecurityConfig: CORS 설정에 PATCH 메서드를 허용하여 API가 정상 동작하도록 수정

---
## 🔗 관련 이슈
Closes #2

---
## ✅ PR 체크리스트
- [x] 기능이 정상 동작함
- [x] 불필요한 코드/콘솔 제거함
- [x] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항