### PR TITLE
Feature/auth

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/auth/token/provider/JwtProvider.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/auth/token/provider/JwtProvider.java
@@ -28,7 +28,7 @@ public class JwtProvider {
     // Refresh 토큰 생성 및 저장 로직 (중복 제거)
     private String createAndSaveRefreshToken(Long id, String username, String role) {
         String refreshToken = JWTUtil.createJWT(id, username, role, false);
-        jwtService.addRefresh(username, refreshToken);
+        jwtService.addRefresh(id, refreshToken);
         return refreshToken;
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/auth/token/service/JwtService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/auth/token/service/JwtService.java
@@ -90,8 +90,8 @@ public class JwtService {
     }
 
     public Boolean existsRefresh(String refreshToken) {
-        String username = JWTUtil.getUsername(refreshToken);
-        String storedToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + username);
+        Long userId = JWTUtil.getId(refreshToken);
+        String storedToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
         return refreshToken.equals(storedToken);
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/GlobalControllerAdvice.java
@@ -2,6 +2,7 @@ package io.github.junhyoung.nearbuy.global.exception;
 
 import io.github.junhyoung.nearbuy.global.exception.business.InvalidPasswordException;
 import io.github.junhyoung.nearbuy.global.exception.business.PostNotFoundException;
+import io.github.junhyoung.nearbuy.global.exception.business.UserAlreadyExistException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -28,6 +29,13 @@ public class GlobalControllerAdvice {
 
     @ExceptionHandler(InvalidPasswordException.class)
     public ResponseEntity<String> handleInvalidPasswordException(InvalidPasswordException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ex.getMessage());
+    }
+
+    @ExceptionHandler(UserAlreadyExistException.class)
+    public ResponseEntity<String> handleInvalidPasswordException(UserAlreadyExistException ex) {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(ex.getMessage());

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/UserAlreadyExistException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/UserAlreadyExistException.java
@@ -1,0 +1,18 @@
+package io.github.junhyoung.nearbuy.global.exception.business;
+
+public class UserAlreadyExistException extends RuntimeException{
+    public UserAlreadyExistException() {
+    }
+
+    public UserAlreadyExistException(String message) {
+        super(message);
+    }
+
+    public UserAlreadyExistException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UserAlreadyExistException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
@@ -58,7 +58,8 @@ public class UserController {
     @DeleteMapping
     public ResponseEntity<Boolean> deleteUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
                                                  @Validated @RequestBody UserDeleteRequestDto dto) {
-        userService.deleteUser(userPrincipal.id(), dto.getTargetId(), UserRoleType.valueOf(userPrincipal.getRole()));
+        UserRoleType currentUserRole = UserRoleType.fromRoleName(userPrincipal.getRole());
+        userService.deleteUser(userPrincipal.id(), dto.getTargetId(), currentUserRole);
         return ResponseEntity.status(200).body(true);
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
@@ -3,6 +3,7 @@ package io.github.junhyoung.nearbuy.user.controller;
 import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
 import io.github.junhyoung.nearbuy.user.dto.request.*;
 import io.github.junhyoung.nearbuy.user.dto.response.UserResponseDto;
+import io.github.junhyoung.nearbuy.user.entity.enumerate.UserRoleType;
 import io.github.junhyoung.nearbuy.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,7 @@ public class UserController {
 
     private final UserService userService;
 
+    // 회원가입 시 username 검증 (프론트엔드에서 실시간으로 요청)
     @PostMapping("/exist")
     public ResponseEntity<Boolean> existUserApi(@Validated @RequestBody UserExistRequestDto userExistRequestDto) {
         return ResponseEntity.ok(userService.isExistUser(userExistRequestDto));
@@ -33,32 +35,31 @@ public class UserController {
         return ResponseEntity.status(201).body(responseBody);
     }
 
-
-    // 유저 정보
+    // 유저 정보 조회
     @GetMapping
-    public UserResponseDto userMeApi(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        return userService.readUserByUsername(userPrincipal.username());
+    public UserResponseDto getUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return userService.readUserById(userPrincipal.id());
     }
 
-    // 유저 수정 (자체 로그인 유저만)
-    @PutMapping
-    public ResponseEntity<Long> updateUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
+    // 유저 정보 수정 (자체 로그인 유저만 가능)
+    @PatchMapping
+    public ResponseEntity<Long> updateLocalUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
                                               @Validated @RequestBody UserUpdateRequestDto dto) {
-        return ResponseEntity.status(200).body(userService.updateUser(userPrincipal.username(), dto));
+        return ResponseEntity.status(200).body(userService.updateLocalUser(userPrincipal.id(), dto));
     }
 
     @PostMapping("/password")
     public ResponseEntity<String> updateUserPasswordApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
                                                         @Validated @RequestBody UserUpdatePasswordRequestDto dto) {
-        userService.updateUserPassword(userPrincipal.username(), dto);
+        userService.updateUserPassword(userPrincipal.id(), dto);
         return ResponseEntity.status(200).body("비밀번호 변경이 완료되었습니다.");
     }
 
     // 유저 제거 (자체/소셜)
     @DeleteMapping
     public ResponseEntity<Boolean> deleteUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                 @Validated @RequestBody UserDeleteRequestDto dto) throws AccessDeniedException {
-        userService.deleteUser(userPrincipal, dto);
+                                                 @Validated @RequestBody UserDeleteRequestDto dto) {
+        userService.deleteUser(userPrincipal.id(), dto.getTargetId(), UserRoleType.valueOf(userPrincipal.getRole()));
         return ResponseEntity.status(200).body(true);
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
@@ -7,7 +7,6 @@ import io.github.junhyoung.nearbuy.user.entity.enumerate.UserRoleType;
 import io.github.junhyoung.nearbuy.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/io/github/junhyoung/nearbuy/user/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/dto/request/UserDeleteRequestDto.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Setter
 public class UserDeleteRequestDto {
 
-    private String username;
+    private Long targetId;
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/user/dto/response/UserResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/dto/response/UserResponseDto.java
@@ -1,4 +1,29 @@
 package io.github.junhyoung.nearbuy.user.dto.response;
 
-public record UserResponseDto(String username, Boolean social, String nickname, String email) {
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserResponseDto {
+    String username;
+    Boolean social;
+    String nickname;
+    String email;
+
+    private UserResponseDto(String username, Boolean social, String nickname, String email) {
+        this.username = username;
+        this.social = social;
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+    public static UserResponseDto createUserResponseDto(UserEntity userEntity) {
+        return new UserResponseDto(userEntity.getUsername(), userEntity.getIsSocial(), userEntity.getNickname(), userEntity.getEmail());
+    }
+
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/user/dto/response/UserResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/dto/response/UserResponseDto.java
@@ -10,12 +10,14 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserResponseDto {
-    String username;
-    Boolean social;
-    String nickname;
-    String email;
+    private Long userId;
+    private String username;
+    private Boolean social;
+    private String nickname;
+    private String email;
 
-    private UserResponseDto(String username, Boolean social, String nickname, String email) {
+    private UserResponseDto(Long userId, String username, Boolean social, String nickname, String email) {
+        this.userId = userId;
         this.username = username;
         this.social = social;
         this.nickname = nickname;
@@ -23,7 +25,13 @@ public class UserResponseDto {
     }
 
     public static UserResponseDto createUserResponseDto(UserEntity userEntity) {
-        return new UserResponseDto(userEntity.getUsername(), userEntity.getIsSocial(), userEntity.getNickname(), userEntity.getEmail());
+        return new UserResponseDto(
+                userEntity.getId(),
+                userEntity.getUsername(),
+                userEntity.getIsSocial(),
+                userEntity.getNickname(),
+                userEntity.getEmail()
+        );
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
@@ -26,7 +26,7 @@ public class UserEntity extends BaseEntity{
     @Column(name = "user_id")
     private Long id;
 
-    @OneToMany(mappedBy = "userEntity", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "userEntity", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostEntity> postEntityList = new ArrayList<>();
 
     @Column(name="username", unique = true, nullable = false, updatable = false)

--- a/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package io.github.junhyoung.nearbuy.user.entity;
 
 import io.github.junhyoung.nearbuy.global.entity.BaseEntity;
+import io.github.junhyoung.nearbuy.global.exception.business.InvalidPasswordException;
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
 import io.github.junhyoung.nearbuy.user.entity.enumerate.SocialProviderType;
 import io.github.junhyoung.nearbuy.user.entity.enumerate.UserRoleType;
@@ -10,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,12 +70,21 @@ public class UserEntity extends BaseEntity{
     }
 
     //== 내부 비즈니스 로직 ==//
-    public void updateUser(UserUpdateRequestDto userUpdateRequestDto) {
-        this.email = userUpdateRequestDto.getEmail();
-        this.nickname = userUpdateRequestDto.getNickname();
+    public void updateUser(String nickname, String email) {
+        this.email = email;
+        this.nickname = nickname;
     }
 
-    public void updateUserPassword(String newPassword) {
-        this.password = newPassword;
+    public void updateUserPassword(String originPassword, String newPassword, String newConfirmPassword, PasswordEncoder passwordEncoder) {
+        // 1. 기존 비밀번호 검증
+        if (!passwordEncoder.matches(originPassword, this.password)) {
+            throw new InvalidPasswordException("기존 비밀번호가 일치하지 않습니다.");
+        }
+        // 2. 새 비밀번호 확인 일치 검증
+        if (!newPassword.equals(newConfirmPassword)) {
+            throw new InvalidPasswordException("새 비밀번호가 서로 일치하지 않습니다.");
+        }
+        // 3. 새 비밀번호로 변경
+        this.password = passwordEncoder.encode(newPassword);
     }
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/user/entity/enumerate/UserRoleType.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/entity/enumerate/UserRoleType.java
@@ -1,5 +1,18 @@
 package io.github.junhyoung.nearbuy.user.entity.enumerate;
 
 public enum UserRoleType {
-    ADMIN, USER
+    ADMIN, USER;
+
+    // "ROLE_" 접두사를 처리하는 정적 팩토리 메소드
+    public static UserRoleType fromRoleName(String roleName) {
+        if (roleName == null) {
+            throw new IllegalArgumentException("Role name must not be null");
+        }
+        if (roleName.startsWith("ROLE_")) {
+            // "ROLE_" 접두사를 제외한 나머지 부분(ex: "USER")으로 Enum 상수
+            return UserRoleType.valueOf(roleName.substring(5));
+        }
+        // 접두사가 없다면 이름 그대로 Enum 상수
+        return UserRoleType.valueOf(roleName);
+    }
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/user/service/SocialLoginService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/service/SocialLoginService.java
@@ -87,7 +87,7 @@ public class SocialLoginService extends DefaultOAuth2UserService {
             UserUpdateRequestDto updateDto = new UserUpdateRequestDto();
             updateDto.setEmail(attributes.email());
             updateDto.setNickname(attributes.nickname());
-            existingUser.updateUser(updateDto);
+            existingUser.updateUser(attributes.nickname(), attributes.email());
             return userRepository.save(existingUser);
         } else {
             // 신규 유저이면, 새로 생성

--- a/src/main/java/io/github/junhyoung/nearbuy/user/service/UserService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/service/UserService.java
@@ -2,6 +2,9 @@ package io.github.junhyoung.nearbuy.user.service;
 
 import io.github.junhyoung.nearbuy.auth.token.service.JwtService;
 import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
+import io.github.junhyoung.nearbuy.global.exception.business.InvalidPasswordException;
+import io.github.junhyoung.nearbuy.global.exception.business.UserAlreadyExistException;
+import io.github.junhyoung.nearbuy.global.exception.business.UserNotFoundException;
 import io.github.junhyoung.nearbuy.user.dto.request.*;
 import io.github.junhyoung.nearbuy.user.dto.response.UserResponseDto;
 import io.github.junhyoung.nearbuy.user.entity.UserEntity;
@@ -39,6 +42,7 @@ public class UserService {
      */
     @Transactional
     public Long join(UserJoinRequestDto userJoinRequestDto) {
+
         validateJoinRequest(userJoinRequestDto);
 
         UserEntity userEntity = UserEntity.builder()
@@ -55,99 +59,83 @@ public class UserService {
     }
 
     /**
-     * 기존 유저의 정보를 수정
+     * 현재 로그인한 유저의 정보를 조회
      */
-    @Transactional
-    public Long updateUser(String username, UserUpdateRequestDto userUpdateRequestDto) {
-        UserEntity userEntity = findUserByUsernameForUpdate(username);
-        userEntity.updateUser(userUpdateRequestDto);
-        return userEntity.getId();
-    }
+    public UserResponseDto readUserById(Long userId) {
+        UserEntity entity = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 회원입니다."));
 
-    @Transactional
-    public void updateUserPassword(String username, UserUpdatePasswordRequestDto dto) {
-        UserEntity findUser = userRepository.findByUsernameAndIsLock(username, false).orElseThrow(() -> new UsernameNotFoundException("회원이 존재하지 않습니다."));
-        // 기존 비밀번호 검증
-        validateOriginPassword(dto.getOriginPassword(), findUser.getPassword());
-        // 새 비밀번호 확인 일치 검증
-        validatePasswordConfirmation(dto.getNewPassword(), dto.getNewConfirmPassword());
-
-        findUser.updateUserPassword(passwordEncoder.encode(dto.getNewPassword()));
+        return UserResponseDto.createUserResponseDto(entity);
     }
 
     /**
-     * 현재 로그인한 유저의 정보를 조회
+     * 기존 유저의 정보를 수정
      */
-    public UserResponseDto readUserByUsername(String username) {
-        UserEntity entity = findUserByUsername(username);
-        return new UserResponseDto(entity.getUsername(), entity.getIsSocial(), entity.getNickname(), entity.getEmail());
+    @Transactional
+    public Long updateLocalUser(Long userId, UserUpdateRequestDto dto) {
+        UserEntity entity = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 회원입니다."));
+
+        entity.updateUser(dto.getNickname(), dto.getEmail());
+        return entity.getId();
+    }
+
+    @Transactional
+    public void updateUserPassword(Long userId, UserUpdatePasswordRequestDto dto) {
+        UserEntity entity = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 회원입니다."));
+
+        // 엔티티의 비즈니스 메서드 호출
+        entity.updateUserPassword(
+                dto.getOriginPassword(),
+                dto.getNewPassword(),
+                dto.getNewConfirmPassword(),
+                passwordEncoder
+        );
     }
 
     /**
      * 유저 탈퇴 처리
      */
     @Transactional
-    public void deleteUser(UserPrincipal userPrincipal, UserDeleteRequestDto dto) throws AccessDeniedException {
-        validateDeleteAuthorization(userPrincipal, dto.getUsername());
+    public void deleteUser(Long currentUserId, Long targetId, UserRoleType currentUserRole){
+        UserEntity userToDelete = userRepository.findById(targetId)
+                .orElseThrow(() -> new UserNotFoundException("삭제할 사용자를 찾을 수 없습니다."));
 
-        userRepository.deleteByUsername(dto.getUsername());
-        jwtService.removeRefreshUser(dto.getUsername());
+        validateDeleteAuthorization(currentUserId, targetId, currentUserRole);
+
+        userRepository.delete(userToDelete);
+        jwtService.removeRefreshUser(userToDelete.getId()); // userId 전달
     }
+
+
 
 
     // =================================================================
     // Private Helper Methods (비즈니스 로직 관련 헬퍼)
     // =================================================================
 
-    private void validateOriginPassword(String rawPassword, String encodedPassword) {
-        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
-            throw new IllegalArgumentException("기존 비밀번호가 일치하지 않습니다.");
-        }
-    }
-
-    private void validatePasswordConfirmation(String newPassword, String confirmPassword) {
-        if (!newPassword.equals(confirmPassword)) {
-            throw new IllegalArgumentException("새 비밀번호가 서로 일치하지 않습니다.");
-        }
-    }
-
     /**
      * 회원가입 요청의 유효성을 검증
      */
     private void validateJoinRequest(UserJoinRequestDto dto) {
         if (!dto.getOriginPassword().equals(dto.getConfirmPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
         }
         if (userRepository.existsByUsername(dto.getUsername())) {
-            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+            throw new UserAlreadyExistException("이미 존재하는 아이디입니다.");
         }
     }
 
     /**
      * 유저 삭제 권한을 검증
      */
-    private void validateDeleteAuthorization(UserPrincipal principal, String targetUsername) {
-        boolean isOwner = principal.username().equals(targetUsername);
-        boolean isAdmin = ("ROLE_" + UserRoleType.ADMIN.name()).equals(principal.getRole());
+    private void validateDeleteAuthorization(Long currentUserId, Long targetUserId, UserRoleType currentUserRole) {
+        boolean isOwner = currentUserId.equals(targetUserId);
+        boolean isAdmin = currentUserRole == UserRoleType.ADMIN;
 
         if (!isOwner && !isAdmin) {
             throw new AccessDeniedException("계정을 삭제할 권한이 없습니다.");
         }
-    }
-
-    /**
-     * 아이디로 유저를 조회
-     */
-    private UserEntity findUserByUsername(String username) {
-        return userRepository.findByUsernameAndIsLock(username, false)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
-    }
-
-    /**
-     * 아이디로 유저를 조회 (수정 전용)
-     */
-    private UserEntity findUserByUsernameForUpdate(String username) {
-        return userRepository.findByUsernameAndIsLockAndIsSocial(username, false, false)
-                .orElseThrow(() -> new UsernameNotFoundException("수정할 사용자를 찾을 수 없습니다: " + username));
     }
 }


### PR DESCRIPTION
## 📌 개요
- 회원 탈퇴 기능: 게시글을 작성한 유저가 탈퇴할 수 없었던 문제와, 권한(Role) 파싱 오류로 인해 탈퇴 요청이 실패하던 버그를 해결
- Refresh Token 검증: Redis에 저장된 토큰을 조회할 때 잘못된 키(key)를 사용하여 토큰이 유효함에도 없다고 판단하던 버그를 수정


---
## 📋 작업 내용
- UserEntity: 회원 탈퇴 버그를 해결하기 위해, @OneToMany 연관관계에 cascade = CascadeType.ALL과 orphanRemoval = true 옵션을 추가하여 유저 삭제 시 게시글이 함께 삭제되도록 수정
- UserRoleType: 권한 파싱 버그를 해결하고 코드의 응집도를 높이기 위해, ROLE_ 접두사를 처리하는 정적 팩토리 메소드(fromRoleName)를 추가
- UserController: UserRoleType의 변경 사항을 적용하여, 역할(Role) 변환 로직을 Enum에 위임하도록 수정
- JwtService: 토큰 검증 버그를 해결하기 위해, Redis 조회 시 username 대신 userId를 사용하도록 로직을 수정

---
## 🔗 관련 이슈
Closes #6


---
## ✅ PR 체크리스트
- [x] 기능이 정상 동작함
- [x] 불필요한 코드/콘솔 제거함
- [x] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항