### PR TITLE
API 응답 및 예외 처리 시스템 전면 개편

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/global/common/ApiResponse.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/common/ApiResponse.java
@@ -1,0 +1,36 @@
+package io.github.junhyoung.nearbuy.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"success", "data", "error"}) // JSON 직렬화 순서 지정
+public class ApiResponse<T> {
+
+    private final boolean success;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T data;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final ErrorResponse error;
+
+    // 성공 시에는 이 메소드를 통해 명확하게 success=true로 객체 생성
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>(true, null, null);
+    }
+
+    // 실패 시에는 이 메소드를 통해 명확하게 success=false로 객체 생성
+    public static ApiResponse<Object> error(ErrorCode errorCode) {
+        return new ApiResponse<>(false, null, new ErrorResponse(errorCode));
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/common/ErrorResponse.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/common/ErrorResponse.java
@@ -1,0 +1,16 @@
+package io.github.junhyoung.nearbuy.global.common;
+
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
+import lombok.Getter;
+
+
+@Getter
+public class ErrorResponse {
+    private final int code;
+    private final String message;
+
+    ErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.getStatus().value();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/BusinessException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package io.github.junhyoung.nearbuy.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/ErrorCode.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/ErrorCode.java
@@ -1,0 +1,27 @@
+package io.github.junhyoung.nearbuy.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 404 NOT_FOUND
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+
+    // 409 CONFLICT
+    USER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),
+
+    // 400 BAD_REQUEST
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 서로 일치하지 않습니다."),
+
+    // 403 FORBIDDEN
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/GlobalControllerAdvice.java
@@ -1,58 +1,27 @@
 package io.github.junhyoung.nearbuy.global.exception;
-
-import io.github.junhyoung.nearbuy.global.exception.business.InvalidPasswordException;
-import io.github.junhyoung.nearbuy.global.exception.business.PostNotFoundException;
-import io.github.junhyoung.nearbuy.global.exception.business.UserAlreadyExistException;
-import org.springframework.http.HttpStatus;
+import io.github.junhyoung.nearbuy.global.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalControllerAdvice {
 
-    @ExceptionHandler(UsernameNotFoundException.class)
-    public ResponseEntity<String> handleUsernameNotFoundException(UsernameNotFoundException ex) {
+    // BusinessException을 상속받는 모든 커스텀 예외를 일괄 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ex.getMessage());
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode));
     }
 
-    @ExceptionHandler(PostNotFoundException.class)
-    public ResponseEntity<String> handlePostNotFoundException(PostNotFoundException ex) {
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ex.getMessage());
-    }
-
-    @ExceptionHandler(InvalidPasswordException.class)
-    public ResponseEntity<String> handleInvalidPasswordException(InvalidPasswordException ex) {
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ex.getMessage());
-    }
-
-    @ExceptionHandler(UserAlreadyExistException.class)
-    public ResponseEntity<String> handleInvalidPasswordException(UserAlreadyExistException ex) {
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ex.getMessage());
-    }
-
+    // Spring Security의 AccessDeniedException 처리
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<String> handleAccessDeniedException(AccessDeniedException ex) {
+    public ResponseEntity<ApiResponse<Object>> handleAccessDeniedException(AccessDeniedException e) {
         return ResponseEntity
-                .status(HttpStatus.FORBIDDEN)
-                .body(ex.getMessage());
+                .status(ErrorCode.ACCESS_DENIED.getStatus())
+                .body(ApiResponse.error(ErrorCode.ACCESS_DENIED));
     }
-
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<String> handleRuntimeException(RuntimeException ex) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ex.getMessage());
-    }
-
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/InvalidPasswordException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/InvalidPasswordException.java
@@ -1,18 +1,10 @@
 package io.github.junhyoung.nearbuy.global.exception.business;
 
-public class InvalidPasswordException extends RuntimeException{
+import io.github.junhyoung.nearbuy.global.exception.BusinessException;
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
+
+public class InvalidPasswordException extends BusinessException {
     public InvalidPasswordException() {
-    }
-
-    public InvalidPasswordException(String message) {
-        super(message);
-    }
-
-    public InvalidPasswordException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public InvalidPasswordException(Throwable cause) {
-        super(cause);
+        super(ErrorCode.INVALID_PASSWORD);
     }
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/NotMatchPasswordException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/NotMatchPasswordException.java
@@ -2,8 +2,9 @@ package io.github.junhyoung.nearbuy.global.exception.business;
 
 import io.github.junhyoung.nearbuy.global.exception.BusinessException;
 import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
-public class UserAlreadyExistException extends BusinessException {
-    public UserAlreadyExistException() {
-        super(ErrorCode.USER_ALREADY_EXIST);
+
+public class NotMatchPasswordException extends BusinessException {
+    public NotMatchPasswordException() {
+        super(ErrorCode.NOT_MATCH_PASSWORD);
     }
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/PostNotFoundException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/PostNotFoundException.java
@@ -1,18 +1,9 @@
 package io.github.junhyoung.nearbuy.global.exception.business;
 
-public class PostNotFoundException extends RuntimeException{
+import io.github.junhyoung.nearbuy.global.exception.BusinessException;
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
+public class PostNotFoundException extends BusinessException {
     public PostNotFoundException() {
-    }
-
-    public PostNotFoundException(String message) {
-        super(message);
-    }
-
-    public PostNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public PostNotFoundException(Throwable cause) {
-        super(cause);
+        super(ErrorCode.POST_NOT_FOUND);
     }
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/UserNotFoundException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/UserNotFoundException.java
@@ -1,19 +1,10 @@
 package io.github.junhyoung.nearbuy.global.exception.business;
 
-public class UserNotFoundException extends RuntimeException{
+import io.github.junhyoung.nearbuy.global.exception.BusinessException;
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
 
+public class UserNotFoundException extends BusinessException {
     public UserNotFoundException() {
-    }
-
-    public UserNotFoundException(String message) {
-        super(message);
-    }
-
-    public UserNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public UserNotFoundException(Throwable cause) {
-        super(cause);
+        super(ErrorCode.USER_NOT_FOUND);
     }
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package io.github.junhyoung.nearbuy.post.controller;
 
 import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
+import io.github.junhyoung.nearbuy.global.common.ApiResponse;
 import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.request.PostDeleteRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
@@ -8,6 +9,7 @@ import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -21,44 +23,38 @@ public class PostController {
 
     private final PostService postService;
 
-    // 게시글 생성
     @PostMapping
-    public ResponseEntity<String> createPostApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                @RequestBody PostCreateRequestDto dto) {
+    public ResponseEntity<ApiResponse<Void>> createPostApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                           @RequestBody PostCreateRequestDto dto) {
         postService.createPost(userPrincipal.id(), dto);
-        return ResponseEntity.status(201).body("게시글 등록이 완료되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
     }
 
-    // 게시글 전체 조회
     @GetMapping
-    public ResponseEntity<List<PostResponseDto>> readPostApi() {
+    public ResponseEntity<ApiResponse<List<PostResponseDto>>> readPostApi() {
         List<PostResponseDto> postResponseDtos = postService.readPosts();
-        return ResponseEntity.status(200).body(postResponseDtos);
+        return ResponseEntity.ok(ApiResponse.success(postResponseDtos));
     }
 
-    // 특정 게시글 상세 조회
     @GetMapping("{postId}")
-    public ResponseEntity<PostDetailResponseDto> readPostDetailApi(@PathVariable Long postId) {
+    public ResponseEntity<ApiResponse<PostDetailResponseDto>> readPostDetailApi(@PathVariable Long postId) {
         PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(postId);
-        return ResponseEntity.status(200).body(postDetailResponseDto);
+        return ResponseEntity.ok(ApiResponse.success(postDetailResponseDto));
     }
 
-    // 게시글 세부 정보 수정
     @PatchMapping("{postId}")
-    public ResponseEntity<String> updatePostApi(@PathVariable Long postId,
-                                                @AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                @RequestBody PostUpdateRequestDto dto) {
+    public ResponseEntity<ApiResponse<Void>> updatePostApi(@PathVariable Long postId,
+                                                           @AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                           @RequestBody PostUpdateRequestDto dto) {
         postService.updatePost(postId, userPrincipal.id(), dto);
-        return ResponseEntity.status(200).body("게시글 수정이 완료되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success());
     }
 
-
-    // DELETE
     @DeleteMapping("{postId}")
-    public ResponseEntity<String> deletePostApi(@PathVariable Long postId,
-                                                @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    public ResponseEntity<ApiResponse<Void>> deletePostApi(@PathVariable Long postId,
+                                                           @AuthenticationPrincipal UserPrincipal userPrincipal) {
         postService.deletePost(postId, userPrincipal.id());
-        return ResponseEntity.status(200).body("게시글 삭제가 완료되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success());
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -1,5 +1,7 @@
 package io.github.junhyoung.nearbuy.post.service;
 
+import io.github.junhyoung.nearbuy.global.exception.business.PostNotFoundException;
+import io.github.junhyoung.nearbuy.global.exception.business.UserNotFoundException;
 import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
@@ -31,7 +33,7 @@ public class PostService {
     @Transactional
     public void createPost(Long authorId, PostCreateRequestDto dto) {
         UserEntity author = userRepository.findById(authorId)
-                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
+                .orElseThrow(UserNotFoundException::new);
 
         PostEntity postEntity = dto.toEntity(author);
         postEntity.setUserEntity(author);
@@ -54,7 +56,7 @@ public class PostService {
     // 게시글 세부 조회
     public PostDetailResponseDto readPostDetail(Long postId) {
         PostEntity postEntity = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));
+                .orElseThrow(PostNotFoundException::new);
 
         return PostDetailResponseDto.builder()
                 .postEntity(postEntity)
@@ -65,7 +67,8 @@ public class PostService {
     @Transactional
     public void updatePost(Long postId, Long userId, PostUpdateRequestDto dto) {
         PostEntity postEntity = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));
+                .orElseThrow(PostNotFoundException::new);
+
         if (!postEntity.getUserEntity().getId().equals(userId)) {
             throw new AccessDeniedException("게시글 수정은 작성자만 가능합니다.");
         }
@@ -76,7 +79,8 @@ public class PostService {
     @Transactional
     public void deletePost(Long postId, Long userId) {
         PostEntity postEntity = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalStateException("존재하지 않는 게시글입니다."));
+                .orElseThrow(PostNotFoundException::new);
+
         if (!postEntity.getUserEntity().getId().equals(userId)) {
             throw new AccessDeniedException("게시글 삭제는 작성자만 가능합니다.");
         }

--- a/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/controller/UserController.java
@@ -1,11 +1,13 @@
 package io.github.junhyoung.nearbuy.user.controller;
 
 import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
+import io.github.junhyoung.nearbuy.global.common.ApiResponse;
 import io.github.junhyoung.nearbuy.user.dto.request.*;
 import io.github.junhyoung.nearbuy.user.dto.response.UserResponseDto;
 import io.github.junhyoung.nearbuy.user.entity.enumerate.UserRoleType;
 import io.github.junhyoung.nearbuy.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -21,46 +23,42 @@ public class UserController {
 
     private final UserService userService;
 
-    // 회원가입 시 username 검증 (프론트엔드에서 실시간으로 요청)
     @PostMapping("/exist")
-    public ResponseEntity<Boolean> existUserApi(@Validated @RequestBody UserExistRequestDto userExistRequestDto) {
-        return ResponseEntity.ok(userService.isExistUser(userExistRequestDto));
+    public ResponseEntity<ApiResponse<Boolean>> existUserApi(@Validated @RequestBody UserExistRequestDto dto) {
+        return ResponseEntity.ok(ApiResponse.success(userService.isExistUser(dto)));
     }
 
     @PostMapping("/join")
-    public ResponseEntity<Map<String, Long>> joinApi(@RequestBody @Validated UserJoinRequestDto userJoinRequestDto) {
-        Long id = userService.join(userJoinRequestDto);
-        Map<String, Long> responseBody = Collections.singletonMap("userId", id);
-        return ResponseEntity.status(201).body(responseBody);
+    public ResponseEntity<ApiResponse<Map<String, Long>>> joinApi(@RequestBody @Validated UserJoinRequestDto dto) {
+        Long id = userService.join(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(Collections.singletonMap("userId", id)));
     }
 
-    // 유저 정보 조회
     @GetMapping
-    public UserResponseDto getUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        return userService.readUserById(userPrincipal.id());
+    public ResponseEntity<ApiResponse<UserResponseDto>> getUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ResponseEntity.ok(ApiResponse.success(userService.readUserById(userPrincipal.id())));
     }
 
-    // 유저 정보 수정 (자체 로그인 유저만 가능)
     @PatchMapping
-    public ResponseEntity<Long> updateLocalUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                              @Validated @RequestBody UserUpdateRequestDto dto) {
-        return ResponseEntity.status(200).body(userService.updateLocalUser(userPrincipal.id(), dto));
+    public ResponseEntity<ApiResponse<Long>> updateLocalUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                                @Validated @RequestBody UserUpdateRequestDto dto) {
+        return ResponseEntity.ok(ApiResponse.success(userService.updateLocalUser(userPrincipal.id(), dto)));
     }
 
     @PostMapping("/password")
-    public ResponseEntity<String> updateUserPasswordApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                        @Validated @RequestBody UserUpdatePasswordRequestDto dto) {
+    public ResponseEntity<ApiResponse<Void>> updateUserPasswordApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                                   @Validated @RequestBody UserUpdatePasswordRequestDto dto) {
         userService.updateUserPassword(userPrincipal.id(), dto);
-        return ResponseEntity.status(200).body("비밀번호 변경이 완료되었습니다.");
+        return ResponseEntity.ok(ApiResponse.success());
     }
 
-    // 유저 제거 (자체/소셜)
     @DeleteMapping
-    public ResponseEntity<Boolean> deleteUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                 @Validated @RequestBody UserDeleteRequestDto dto) {
-        UserRoleType currentUserRole = UserRoleType.fromRoleName(userPrincipal.getRole());
-        userService.deleteUser(userPrincipal.id(), dto.getTargetId(), currentUserRole);
-        return ResponseEntity.status(200).body(true);
+    public ResponseEntity<ApiResponse<Void>> deleteUserApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                           @Validated @RequestBody UserDeleteRequestDto dto) {
+        UserRoleType role = UserRoleType.fromRoleName(userPrincipal.getRole());
+        userService.deleteUser(userPrincipal.id(), dto.getTargetId(), role);
+        return ResponseEntity.ok(ApiResponse.success());
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/entity/UserEntity.java
@@ -78,11 +78,11 @@ public class UserEntity extends BaseEntity{
     public void updateUserPassword(String originPassword, String newPassword, String newConfirmPassword, PasswordEncoder passwordEncoder) {
         // 1. 기존 비밀번호 검증
         if (!passwordEncoder.matches(originPassword, this.password)) {
-            throw new InvalidPasswordException("기존 비밀번호가 일치하지 않습니다.");
+            throw new InvalidPasswordException();
         }
         // 2. 새 비밀번호 확인 일치 검증
         if (!newPassword.equals(newConfirmPassword)) {
-            throw new InvalidPasswordException("새 비밀번호가 서로 일치하지 않습니다.");
+            throw new InvalidPasswordException();
         }
         // 3. 새 비밀번호로 변경
         this.password = passwordEncoder.encode(newPassword);

--- a/src/main/java/io/github/junhyoung/nearbuy/user/service/UserService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/user/service/UserService.java
@@ -3,6 +3,7 @@ package io.github.junhyoung.nearbuy.user.service;
 import io.github.junhyoung.nearbuy.auth.token.service.JwtService;
 import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
 import io.github.junhyoung.nearbuy.global.exception.business.InvalidPasswordException;
+import io.github.junhyoung.nearbuy.global.exception.business.NotMatchPasswordException;
 import io.github.junhyoung.nearbuy.global.exception.business.UserAlreadyExistException;
 import io.github.junhyoung.nearbuy.global.exception.business.UserNotFoundException;
 import io.github.junhyoung.nearbuy.user.dto.request.*;
@@ -63,7 +64,7 @@ public class UserService {
      */
     public UserResponseDto readUserById(Long userId) {
         UserEntity entity = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 회원입니다."));
+                .orElseThrow(UserNotFoundException::new);
 
         return UserResponseDto.createUserResponseDto(entity);
     }
@@ -74,7 +75,7 @@ public class UserService {
     @Transactional
     public Long updateLocalUser(Long userId, UserUpdateRequestDto dto) {
         UserEntity entity = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 회원입니다."));
+                .orElseThrow(UserNotFoundException::new);
 
         entity.updateUser(dto.getNickname(), dto.getEmail());
         return entity.getId();
@@ -83,7 +84,7 @@ public class UserService {
     @Transactional
     public void updateUserPassword(Long userId, UserUpdatePasswordRequestDto dto) {
         UserEntity entity = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 회원입니다."));
+                .orElseThrow(UserNotFoundException::new);
 
         // 엔티티의 비즈니스 메서드 호출
         entity.updateUserPassword(
@@ -100,7 +101,7 @@ public class UserService {
     @Transactional
     public void deleteUser(Long currentUserId, Long targetId, UserRoleType currentUserRole){
         UserEntity userToDelete = userRepository.findById(targetId)
-                .orElseThrow(() -> new UserNotFoundException("삭제할 사용자를 찾을 수 없습니다."));
+                .orElseThrow(UserNotFoundException::new);
 
         validateDeleteAuthorization(currentUserId, targetId, currentUserRole);
 
@@ -120,10 +121,10 @@ public class UserService {
      */
     private void validateJoinRequest(UserJoinRequestDto dto) {
         if (!dto.getOriginPassword().equals(dto.getConfirmPassword())) {
-            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+            throw new NotMatchPasswordException();
         }
         if (userRepository.existsByUsername(dto.getUsername())) {
-            throw new UserAlreadyExistException("이미 존재하는 아이디입니다.");
+            throw new UserAlreadyExistException();
         }
     }
 


### PR DESCRIPTION
## 📌 개요
API 응답 및 예외 처리 시스템 전면 개편

---
## 📋 작업 내용
- `ApiResponse`: 모든 API 응답을 감싸는 공통 래퍼 클래스를 추가하여, 성공/실패 응답 형식을 `{ "success": boolean, "data": T, "error": ErrorResponse }`로 표준화
- `ErrorCode`: 애플리케이션의 모든 예외 상황을 Enum으로 정의하여, 오류코드와 메시지를 중앙에서 체계적으로 관리
- `BusinessException`: 모든 도메인별 커스텀 예외가 상속받는 최상위 예외 클래스를 추가하여, 비즈니스 로직 예외를 일관되게 처리할 수 있는 기반을 마련

- `GlobalControllerAdvice`: `@RestControllerAdvice`가 `BusinessException`을 일괄 처리하도록 변경하여, 여러 `ExceptionHandler`를 하나로 통합 및 모든 예외 응답이	`ApiResponse` 형식으로 반환되도록 수정
- All Controllers (`User`, `Post`): 모든 API 메소드의 반환  타입을 `ResponseEntity<ApiResponse<T>>`로 변경하여, 명시적인 HTTP 상태 코드와 표준화된 응답 본문을 함께 반환하도록 통일
- All Custom Exceptions: 기존의 모든 커스텀 예외(`UserNotFoundException` 등)가 `BusinessException`을 상속받도록 수정
- Service Layer (`User`, `Post`): `IllegalStateException` 등 일반 예외를 사용하던 부분을 `ErrorCode`에 정의된 도메인 특화 커스텀 예외(`PostNotFoundException` 등)를 던지도록 수정하여 예외 발생의 원인 파악

- `ApiResponse` 생성자: `ApiResponse.success()` 호출 시 `null` 값으로 인해 생성자 추론이 모호해져 발생하던 `NullPointerException` 버그를 생성자 로직을 수정하여 해결"# On branch feature/auth

---
## 🔗 관련 이슈
Closes #8

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항