### PR TITLE
fix(SecurityConfig): 비로그인 사용자를 위한 게시글 조회 URL 허용

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
@@ -118,6 +118,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/login").permitAll() // 로그인
                         .requestMatchers("/jwt/exchange", "/jwt/refresh").permitAll() // JWT 관련 API 호출
+                        .requestMatchers(HttpMethod.GET, "/post", "/post/**").permitAll() // 게시글 조회는 모두 허용
                         .requestMatchers(HttpMethod.POST, "/user/exist", "/user/join").permitAll() // 회원가입
                         .requestMatchers(HttpMethod.GET, "/user").hasRole(UserRoleType.USER.name()) // 유저 정보 조회
                         .requestMatchers(HttpMethod.PUT, "/user").hasRole(UserRoleType.USER.name()) // 유저 정보 수정


### PR DESCRIPTION
## 📌 개요
비로그인 사용자를 위한 게시글 조회 URL 허용

---
## 📋 작업 내용
/post/**에 대한 GET 요청(게시글 전체 조회, 게시글 상세 조회)는 인가/인증 없이 모두 접근 허용

---
## 🔗 관련 이슈

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항