### PR TITLE
feat: 게시글 다중 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
@@ -118,6 +118,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/login").permitAll() // 로그인
                         .requestMatchers("/jwt/exchange", "/jwt/refresh").permitAll() // JWT 관련 API 호출
+                        .requestMatchers("/images/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/post", "/post/**").permitAll() // 게시글 조회는 모두 허용
                         .requestMatchers(HttpMethod.POST, "/user/exist", "/user/join").permitAll() // 회원가입
                         .requestMatchers(HttpMethod.GET, "/user").hasRole(UserRoleType.USER.name()) // 유저 정보 조회

--- a/src/main/java/io/github/junhyoung/nearbuy/config/WebMvcConfig.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package io.github.junhyoung.nearbuy.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Value("${file.dir}")
+    private String fileDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // /images/** URL 요청 시, file.dir 경로에서 파일을 찾아 제공
+        // 'file:' 접두사는 로컬 파일 시스템의 경로임을 명시
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:" + fileDir);
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/util/FileStore.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/util/FileStore.java
@@ -1,0 +1,16 @@
+package io.github.junhyoung.nearbuy.global.util;
+
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * 파일 저장을 위한 인터페이스
+ * ㄴ 로컬 저장, S3 등 다양한 저장 방식에 대한 확장성 제공
+ */
+public interface FileStore {
+    String storeFile(MultipartFile multipartFile) throws IOException;
+
+    List<String> storeFiles(List<MultipartFile> multipartFiles) throws IOException;
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/util/LocalFileStore.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/util/LocalFileStore.java
@@ -1,0 +1,71 @@
+package io.github.junhyoung.nearbuy.global.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class LocalFileStore implements FileStore{
+
+    @Value("${file.dir}")
+    private String fileDir;
+
+    @Override
+    public String storeFile(MultipartFile multipartFile) throws IOException {
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            return null;
+        }
+
+        String originalFilename = multipartFile.getOriginalFilename();
+        String storeFileName = createStoreFileName(originalFilename);
+
+        File directory = new File(fileDir);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        multipartFile.transferTo(new File(getFullPath(storeFileName)));
+
+        // 클라이언트가 접근할 URL 경로를 반환 (전체 경로가 아님)
+        return "/images/" + storeFileName;
+    }
+
+    @Override
+    public List<String> storeFiles(List<MultipartFile> multipartFiles) throws IOException {
+
+        List<String> storeFileResult = new ArrayList<>();
+
+        if (multipartFiles == null || multipartFiles.isEmpty()) {
+            return storeFileResult;
+        }
+
+        for (MultipartFile multipartFile : multipartFiles) {
+            if (!multipartFile.isEmpty()) {
+                storeFileResult.add(storeFile(multipartFile)); // storeFile() 메서드 내부 호출
+            }
+        }
+        return storeFileResult;
+    }
+
+    public String getFullPath(String filename) {
+        return fileDir + filename.replace("/images/", "");
+    }
+
+    private String createStoreFileName(String originalFilename) {
+        String ext = extractExt(originalFilename);
+        String uuid = UUID.randomUUID().toString();
+        return uuid + "." + ext;
+    }
+
+    private String extractExt(String originalFilename) {
+        int pos = originalFilename.lastIndexOf(".");
+        return originalFilename.substring(pos + 1);
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/util/S3FileStore.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/util/S3FileStore.java
@@ -1,0 +1,4 @@
+package io.github.junhyoung.nearbuy.global.util;
+
+public class S3FileStore {
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -9,10 +9,13 @@ import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -22,10 +25,13 @@ public class PostController {
 
     private final PostService postService;
 
-    @PostMapping
-    public ResponseEntity<ApiResponse<Void>> createPostApi(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                           @RequestBody PostCreateRequestDto dto) {
-        postService.createPost(userPrincipal.id(), dto);
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ApiResponse<Void>> createPostApi(
+                        @AuthenticationPrincipal UserPrincipal userPrincipal,
+                        @RequestPart("dto") PostCreateRequestDto dto,
+                        @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
+
+        postService.createPost(userPrincipal.id(), dto, images);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
     }
 
@@ -41,11 +47,14 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.success(postDetailResponseDto));
     }
 
-    @PatchMapping("{postId}")
-    public ResponseEntity<ApiResponse<Void>> updatePostApi(@PathVariable Long postId,
-                                                           @AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                           @RequestBody PostUpdateRequestDto dto) {
-        postService.updatePost(postId, userPrincipal.id(), dto);
+    @PatchMapping(value = "/{postId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ApiResponse<Void>> updatePostApi(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestPart("dto") PostUpdateRequestDto dto,
+            @RequestPart(value = "addImages", required = false) List<MultipartFile> addImages) throws IOException {
+
+        postService.updatePost(postId, userPrincipal.id(), dto, addImages);
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -28,10 +28,10 @@ public class PostController {
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ApiResponse<Void>> createPostApi(
                         @AuthenticationPrincipal UserPrincipal userPrincipal,
-                        @RequestPart("dto") PostCreateRequestDto dto,
+                        @RequestPart("postCreateRequestDto") PostCreateRequestDto postCreateRequestDto,
                         @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
 
-        postService.createPost(userPrincipal.id(), dto, images);
+        postService.createPost(userPrincipal.id(), postCreateRequestDto, images);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostCreateRequestDto.java
@@ -20,8 +20,6 @@ public class PostCreateRequestDto {
 
     private ProductCategory productCategory;
 
-    private String imageUrl;
-
     public PostEntity toEntity(UserEntity userEntity) {
         return PostEntity.builder()
                 .userEntity(userEntity)
@@ -30,7 +28,6 @@ public class PostCreateRequestDto {
                 .price(this.price)
                 .productCategory(this.productCategory)
                 .postStatus(PostStatus.ON_SALE)
-                .imageUrl(this.imageUrl)
                 .build();
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostUpdateRequestDto.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +26,6 @@ public class PostUpdateRequestDto {
 
     private PostStatus postStatus;
 
-    private String imageUrl;
+    private List<String> deleteImageUrls;
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
@@ -5,6 +5,9 @@ import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -28,6 +31,8 @@ public class PostDetailResponseDto {
 
     private LocalDateTime createdAt;
 
+    private List<PostImageResponseDto> postImages = new ArrayList<>();
+
     private PostDetailResponseDto(PostEntity postEntity) {
         this.postId = postEntity.getId();
         this.authorId = postEntity.getUserEntity().getId();
@@ -37,6 +42,9 @@ public class PostDetailResponseDto {
         this.price = postEntity.getPrice();
         this.productCategory = postEntity.getProductCategory();
         this.createdAt = postEntity.getCreatedAt();
+        this.postImages = postEntity.getPostImageEntityList().stream()
+                .map(PostImageResponseDto::new)
+                .collect(Collectors.toList());
     }
 
     public static PostDetailResponseDto from(PostEntity postEntity) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
@@ -28,8 +28,6 @@ public class PostDetailResponseDto {
 
     private LocalDateTime createdAt;
 
-    private String imageUrl;
-
     private PostDetailResponseDto(PostEntity postEntity) {
         this.postId = postEntity.getId();
         this.authorId = postEntity.getUserEntity().getId();
@@ -39,7 +37,6 @@ public class PostDetailResponseDto {
         this.price = postEntity.getPrice();
         this.productCategory = postEntity.getProductCategory();
         this.createdAt = postEntity.getCreatedAt();
-        this.imageUrl = postEntity.getImageUrl();
     }
 
     public static PostDetailResponseDto from(PostEntity postEntity) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostImageResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostImageResponseDto.java
@@ -1,0 +1,18 @@
+package io.github.junhyoung.nearbuy.post.dto.response;
+
+import io.github.junhyoung.nearbuy.post.entity.PostImageEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImageResponseDto {
+    private Long id;
+    private String imageUrl;
+
+    public PostImageResponseDto(PostImageEntity postImageEntity) {
+        this.id = postImageEntity.getId();
+        this.imageUrl = postImageEntity.getImageUrl();
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
@@ -5,6 +5,9 @@ import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -23,6 +26,8 @@ public class PostResponseDto {
 
     private LocalDateTime createdAt;
 
+    private List<PostImageResponseDto> postImages = new ArrayList<>();
+
     private PostResponseDto(PostEntity postEntity) {
         this.postId = postEntity.getId();
         this.authorNickname = postEntity.getUserEntity().getNickname();
@@ -30,6 +35,9 @@ public class PostResponseDto {
         this.price = postEntity.getPrice();
         this.productCategory = postEntity.getProductCategory();
         this.createdAt = postEntity.getCreatedAt();
+        this.postImages = postEntity.getPostImageEntityList().stream()
+                .map(PostImageResponseDto::new)
+                .collect(Collectors.toList());
     }
 
     public static PostResponseDto from(PostEntity postEntity) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
@@ -26,7 +26,7 @@ public class PostResponseDto {
 
     private LocalDateTime createdAt;
 
-    private List<PostImageResponseDto> postImages = new ArrayList<>();
+    private PostImageResponseDto postImage;
 
     private PostResponseDto(PostEntity postEntity) {
         this.postId = postEntity.getId();
@@ -35,9 +35,10 @@ public class PostResponseDto {
         this.price = postEntity.getPrice();
         this.productCategory = postEntity.getProductCategory();
         this.createdAt = postEntity.getCreatedAt();
-        this.postImages = postEntity.getPostImageEntityList().stream()
+        this.postImage = postEntity.getPostImageEntityList().stream()
+                .findFirst()
                 .map(PostImageResponseDto::new)
-                .collect(Collectors.toList());
+                .orElse(null);
     }
 
     public static PostResponseDto from(PostEntity postEntity) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
@@ -23,8 +23,6 @@ public class PostResponseDto {
 
     private LocalDateTime createdAt;
 
-    private String imageUrl;
-
     private PostResponseDto(PostEntity postEntity) {
         this.postId = postEntity.getId();
         this.authorNickname = postEntity.getUserEntity().getNickname();
@@ -32,7 +30,6 @@ public class PostResponseDto {
         this.price = postEntity.getPrice();
         this.productCategory = postEntity.getProductCategory();
         this.createdAt = postEntity.getCreatedAt();
-        this.imageUrl = postEntity.getImageUrl();
     }
 
     public static PostResponseDto from(PostEntity postEntity) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
@@ -11,6 +11,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,8 +45,8 @@ public class PostEntity extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private ProductCategory productCategory;
 
-    @Column(name = "imageUrl")
-    private String imageUrl;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostImageEntity> postImageEntityList = new ArrayList<>();
 
     @Builder
     public PostEntity(UserEntity userEntity, String title, String contents, Integer price, ProductCategory productCategory, PostStatus postStatus, String imageUrl) {
@@ -53,13 +56,16 @@ public class PostEntity extends BaseEntity {
         this.price = price;
         this.productCategory = productCategory;
         this.postStatus = postStatus;
-        this.imageUrl = imageUrl;
     }
 
     //== 연관관계 편의 메서드 ==//
     public void setUserEntity(UserEntity userEntity) {
         this.userEntity = userEntity;   // 게시글 작성자 설정
         userEntity.getPostEntityList().add(this);   // 사용자가 작성한 게시글에 현재 게시글 추가
+    }
+
+    public void addPostImageEntity(PostImageEntity postImageEntity) {
+        this.postImageEntityList.add(postImageEntity);
     }
 
     //== 내부 메서드 ==//
@@ -78,9 +84,6 @@ public class PostEntity extends BaseEntity {
         }
         if (dto.getProductCategory() != null) {
             this.productCategory = dto.getProductCategory();
-        }
-        if (dto.getImageUrl() != null) {
-            this.imageUrl = dto.getImageUrl();
         }
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostImageEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostImageEntity.java
@@ -1,0 +1,34 @@
+package io.github.junhyoung.nearbuy.post.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PostImageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private PostEntity post;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Builder
+    public PostImageEntity(PostEntity post, String imageUrl) {
+        this.post = post;
+        this.imageUrl = imageUrl;
+    }
+
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostImageRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostImageRepository.java
@@ -1,10 +1,15 @@
 package io.github.junhyoung.nearbuy.post.repository;
 
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.PostImageEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<PostEntity, Long> {
+public interface PostImageRepository extends JpaRepository<PostImageEntity, Long> {
+
+    @Transactional
+    void deleteByImageUrlIn(List<String> imageUrls);
+
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
@@ -2,6 +2,13 @@ package io.github.junhyoung.nearbuy.post.repository;
 
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+    @Transactional
+    void deleteByImageUrlIn(List<String> imageUrls);
+
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -9,6 +9,7 @@ import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
 import io.github.junhyoung.nearbuy.post.entity.PostImageEntity;
+import io.github.junhyoung.nearbuy.post.repository.PostImageRepository;
 import io.github.junhyoung.nearbuy.post.repository.PostRepository;
 import io.github.junhyoung.nearbuy.user.entity.UserEntity;
 import io.github.junhyoung.nearbuy.user.repository.UserRepository;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
     private final UserRepository userRepository;
     private final FileStore fileStore;
 
@@ -94,7 +96,7 @@ public class PostService {
 
         // 4. 이미지 삭제 처리
         if (dto.getDeleteImageUrls() != null && !dto.getDeleteImageUrls().isEmpty()) {
-            postRepository.deleteByImageUrlIn(dto.getDeleteImageUrls());
+            postImageRepository.deleteByImageUrlIn(dto.getDeleteImageUrls());
         }
 
         // 5. 이미지 추가 처리

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -2,11 +2,13 @@ package io.github.junhyoung.nearbuy.post.service;
 
 import io.github.junhyoung.nearbuy.global.exception.business.PostNotFoundException;
 import io.github.junhyoung.nearbuy.global.exception.business.UserNotFoundException;
+import io.github.junhyoung.nearbuy.global.util.FileStore;
 import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.PostImageEntity;
 import io.github.junhyoung.nearbuy.post.repository.PostRepository;
 import io.github.junhyoung.nearbuy.user.entity.UserEntity;
 import io.github.junhyoung.nearbuy.user.repository.UserRepository;
@@ -16,7 +18,9 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,15 +32,29 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final FileStore fileStore;
 
     // 게시글 생성
     @Transactional
-    public void createPost(Long authorId, PostCreateRequestDto dto) {
+    public void createPost(Long authorId, PostCreateRequestDto dto, List<MultipartFile> images) throws IOException {
         UserEntity author = userRepository.findById(authorId)
                 .orElseThrow(UserNotFoundException::new);
 
+        // 1. PostEntity 먼저 생성 (Builder에서 imageUrl 제거)
         PostEntity postEntity = dto.toEntity(author);
         postEntity.setUserEntity(author);
+
+        // 2. 파일들 저장
+        List<String> imageUrls = fileStore.storeFiles(images);
+
+        // 3. 각 이미지 URL을 PostImage 엔티티로 만들어 PostEntity에 추가
+        for (String imageUrl : imageUrls) {
+            PostImageEntity postImageEntity = PostImageEntity.builder()
+                    .post(postEntity)
+                    .imageUrl(imageUrl)
+                    .build();
+            postEntity.addPostImageEntity(postImageEntity);
+        }
 
         postRepository.save(postEntity);
     }
@@ -62,14 +80,32 @@ public class PostService {
 
     // 게시글 세부 정보 수정
     @Transactional
-    public void updatePost(Long postId, Long userId, PostUpdateRequestDto dto) {
+    public void updatePost(Long postId, Long userId, PostUpdateRequestDto dto, List<MultipartFile> addImages) throws IOException {
         PostEntity postEntity = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
 
+        // 2. 권한 확인
         if (!postEntity.getUserEntity().getId().equals(userId)) {
             throw new AccessDeniedException("게시글 수정은 작성자만 가능합니다.");
         }
+
+        // 3. 텍스트 정보 업데이트 (엔티티 내부 메서드 호출)
         postEntity.updatePostDetail(dto);
+
+        // 4. 이미지 삭제 처리
+        if (dto.getDeleteImageUrls() != null && !dto.getDeleteImageUrls().isEmpty()) {
+            postRepository.deleteByImageUrlIn(dto.getDeleteImageUrls());
+        }
+
+        // 5. 이미지 추가 처리
+        List<String> newImageUrls = fileStore.storeFiles(addImages);
+        for (String imageUrl : newImageUrls) {
+            PostImageEntity newPostImage = PostImageEntity.builder()
+                    .post(postEntity)
+                    .imageUrl(imageUrl)
+                    .build();
+            postEntity.addPostImageEntity(newPostImage);
+        }
     }
 
     // 게시글 삭제


### PR DESCRIPTION
## 📌 개요
- 게시글 작성 및 수정 시 여러 장의 이미지를 첨부할 수 있도록 기능을 추가하고, 로컬 파일 시스템에 저장하는 로직을 구현
- S3 등 향후 다른 스토리지 서비스로의 확장을 고려하여 파일 저장 로직을 인터페이스 기반으로 설계

---
## 📋 작업 내용
- FileStore.java: 파일 저장 로직의 표준을 정의하는 인터페이스 추가.
- LocalFileStore.java: FileStore 인터페이스를 구현한 로컬 파일 저장 서비스 클래스 추가.
- PostImage.java, PostImageRepository.java: 게시글과 이미지의 다대일 관계 매핑을 위한 엔티티 및 리포지토리 추가.
- WebMvcConfig.java: 업로드된 이미지에 외부에서 접근할 수 있도록 정적 리소스 핸들러 설정 추가.
- application.yml: 파일이 저장될 로컬 디렉토리 경로(file.dir) 설정 추가.
 
- PostEntity: 기존 imageUrl 필드를 삭제하고, PostImage와 @OneToMany 연관관계 매핑.
- PostService: 단일/다중 파일을 처리하고 PostImage 엔티티를 함께 저장하도록 생성 및 수정 로직 변경.
- PostController: multipart/form-data 요청을 통해 여러 이미지 파일(List<MultipartFile>)을 받을 수 있도록 API 파라미터 수정.
- PostUpdateRequestDto: 수정 시 삭제할 이미지 URL 목록을 받을 수 있도록 deleteImageUrls 필드 추가.

---
## 🔗 관련 이슈
Closes #13


---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항