### PR TITLE
feat(post): 게시글 목록 조회 성능 개선 및 Slice 페이징 적용

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -8,6 +8,8 @@ import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -36,8 +38,8 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PostResponseDto>>> readPostApi() {
-        List<PostResponseDto> postResponseDtos = postService.readPosts();
+    public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> readPostApi(Pageable pageable) {
+        Slice<PostResponseDto> postResponseDtos = postService.readPosts(pageable);
         return ResponseEntity.ok(ApiResponse.success(postResponseDtos));
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
@@ -1,10 +1,18 @@
 package io.github.junhyoung.nearbuy.post.repository;
 
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+    @Query(value = "SELECT p FROM PostEntity p JOIN FETCH p.userEntity u")
+    Slice<PostEntity> findAllWithUser(Pageable pageable);
+
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -15,6 +15,8 @@ import io.github.junhyoung.nearbuy.user.entity.UserEntity;
 import io.github.junhyoung.nearbuy.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -62,14 +64,9 @@ public class PostService {
     }
 
     // 게시글 전체 조회
-    public List<PostResponseDto> readPosts() {
-        List<PostEntity> posts = postRepository.findAll();
-
-        List<PostResponseDto> postResponseDtos = posts.stream()
-                .map(PostResponseDto::from)
-                .collect(Collectors.toList());
-
-        return postResponseDtos;
+    public Slice<PostResponseDto> readPosts(Pageable pageable) {
+        Slice<PostEntity> posts = postRepository.findAllWithUser(pageable);
+        return posts.map(PostResponseDto::from);
     }
 
     // 게시글 세부 조회


### PR DESCRIPTION
## 📌 개요
기존 게시글 전체 조회 방식에서 발생하던 N+1 문제를 해결하고, 향후 무한 스크롤 기능 구현에 용이하도록 Slice 기반의 페이징을 도입

---
## 📋 작업 내용
- PostController: readPostApi가 Pageable 객체를 파라미터로 받아 Slice<PostResponseDto>를 반환하도록 수정
- PostService: readPosts 메서드가 Pageable을 받아 비즈니스 로직을 처리하도록 변경
- PostRepository: findAllWithUser 메서드를 추가하여, Fetch Join과 페이징이 적용된 Slice<PostEntity>를 반환하도록 구현

---
## 🔗 관련 이슈
Closes #17

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항