### PR TITLE
feat: 마이페이지 나의 거래 내역 조회 API 추가

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/config/SecurityConfig.java
@@ -122,7 +122,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/post", "/post/**").permitAll() // 게시글 조회는 모두 허용
                         .requestMatchers(HttpMethod.POST, "/user/exist", "/user/join").permitAll() // 회원가입
                         .requestMatchers(HttpMethod.GET, "/user").hasRole(UserRoleType.USER.name()) // 유저 정보 조회
-                        .requestMatchers(HttpMethod.PUT, "/user").hasRole(UserRoleType.USER.name()) // 유저 정보 수정
+                        .requestMatchers(HttpMethod.PATCH, "/user").hasRole(UserRoleType.USER.name()) // 유저 정보 수정
                         .requestMatchers(HttpMethod.DELETE, "/user").hasRole(UserRoleType.USER.name()) // 유저 삭제
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -4,6 +4,7 @@ import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
 import io.github.junhyoung.nearbuy.global.common.ApiResponse;
 import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.response.MyPostResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.service.PostService;
@@ -27,6 +28,7 @@ public class PostController {
 
     private final PostService postService;
 
+    // 게시글 등록
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ApiResponse<Void>> createPostApi(
                         @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -37,18 +39,30 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
     }
 
+    // 게시글 전체 조회
     @GetMapping
     public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> readPostApi(Pageable pageable) {
         Slice<PostResponseDto> postResponseDtos = postService.readPosts(pageable);
         return ResponseEntity.ok(ApiResponse.success(postResponseDtos));
     }
 
+    // 내 게시글 전체 조회
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<Slice<MyPostResponseDto>>> readMyPostApi(
+                                @AuthenticationPrincipal UserPrincipal userPrincipal,
+                                Pageable pageable) {
+        Slice<MyPostResponseDto> postResponseDtos = postService.readMyPosts(userPrincipal.id(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(postResponseDtos));
+    }
+
+    // 게시글 상세 조회
     @GetMapping("{postId}")
     public ResponseEntity<ApiResponse<PostDetailResponseDto>> readPostDetailApi(@PathVariable Long postId) {
         PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(postId);
         return ResponseEntity.ok(ApiResponse.success(postDetailResponseDto));
     }
 
+    // 게시글 수정
     @PatchMapping(value = "/{postId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ApiResponse<Void>> updatePostApi(
             @PathVariable Long postId,
@@ -60,6 +74,7 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.success());
     }
 
+    // 게시글 삭제
     @DeleteMapping("{postId}")
     public ResponseEntity<ApiResponse<Void>> deletePostApi(@PathVariable Long postId,
                                                            @AuthenticationPrincipal UserPrincipal userPrincipal) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/MyPostResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/MyPostResponseDto.java
@@ -1,0 +1,46 @@
+package io.github.junhyoung.nearbuy.post.dto.response;
+
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyPostResponseDto {
+
+    private Long postId;
+
+    private String title;
+
+    private Integer price;
+
+    private LocalDateTime createdAt;
+
+    private PostImageResponseDto postImage;
+
+    private PostStatus status;
+
+    private MyPostResponseDto(PostEntity postEntity) {
+        this.postId = postEntity.getId();
+        this.title = postEntity.getTitle();
+        this.price = postEntity.getPrice();
+        this.createdAt = postEntity.getCreatedAt();
+        this.status = postEntity.getPostStatus();
+        this.postImage = postEntity.getPostImageEntityList().stream()
+                .findFirst()
+                .map(PostImageResponseDto::new)
+                .orElse(null);
+    }
+
+    public static MyPostResponseDto from(PostEntity postEntity) {
+        return new MyPostResponseDto(postEntity);
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -14,5 +15,10 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
     @Query(value = "SELECT p FROM PostEntity p JOIN FETCH p.userEntity u")
     Slice<PostEntity> findAllWithUser(Pageable pageable);
+
+    @Query(value = "SELECT p FROM PostEntity p " +
+            "LEFT JOIN FETCH p.userEntity u " +
+            "WHERE p.userEntity.id=:userId")
+    Slice<PostEntity> findMyPosts(@Param(value="userId") Long userId, Pageable pageable);
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -5,6 +5,7 @@ import io.github.junhyoung.nearbuy.global.exception.business.UserNotFoundExcepti
 import io.github.junhyoung.nearbuy.global.util.FileStore;
 import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.response.MyPostResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
 import io.github.junhyoung.nearbuy.post.entity.PostEntity;
@@ -67,6 +68,12 @@ public class PostService {
     public Slice<PostResponseDto> readPosts(Pageable pageable) {
         Slice<PostEntity> posts = postRepository.findAllWithUser(pageable);
         return posts.map(PostResponseDto::from);
+    }
+
+    // 나의 게시글 전체 조회
+    public Slice<MyPostResponseDto> readMyPosts(Long userId,Pageable pageable) {
+        Slice<PostEntity> posts = postRepository.findMyPosts(userId, pageable);
+        return posts.map(MyPostResponseDto::from);
     }
 
     // 게시글 세부 조회


### PR DESCRIPTION
## 📌 개요
마이페이지 나의 거래 내역 조회 API 추가
---
## 📋 작업 내용
- MyPostResponseDto: 나의 거래 내역 조회를 위한 전용 데이터 전송 객체 (DTO) 추가
- PostController: 인증된 사용자의 판매 게시글 목록을 조회하는 GET /post/my-posts API 엔드포인트 추가
- PostService: 사용자 ID를 기반으로 판매 내역을 조회하는 readMyPosts 비즈니스 로직 구현
- PostRepository: 특정 사용자의 게시글을 페이징하여 조회하는 findMyPostsByUserId 쿼리 메서드 추가
- SecurityConfig: /post/my-posts 경로에 대한 접근 권한 설정 추가
---
## 🔗 관련 이슈
Closes #19
---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음
---
## 💬 기타 사항