### PR TITLE
refactor: JwtService 로직 개선 및 토큰 예외 처리 구체화

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/auth/token/service/JwtService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/auth/token/service/JwtService.java
@@ -3,6 +3,9 @@ package io.github.junhyoung.nearbuy.auth.token.service;
 import io.github.junhyoung.nearbuy.auth.web.util.JWTUtil;
 import io.github.junhyoung.nearbuy.auth.token.dto.request.RefreshRequestDto;
 import io.github.junhyoung.nearbuy.auth.token.dto.response.JWTResponseDto;
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
+import io.github.junhyoung.nearbuy.global.exception.business.InvalidRefreshTokenException;
+import io.github.junhyoung.nearbuy.global.exception.business.RefreshTokenNotFoundException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,32 +32,17 @@ public class JwtService {
 
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
-            throw new RuntimeException("쿠키가 존재하지 않습니다.");
+            throw new RefreshTokenNotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
-
 
         String refreshToken = Arrays.stream(cookies)
                 .filter(cookie -> "refreshToken".equals(cookie.getName()))
                 .findFirst()
                 .map(Cookie::getValue)
-                .orElseThrow(() -> new RuntimeException("refreshToken 쿠키가 없습니다."));
+                .orElseThrow(() -> new RefreshTokenNotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
-
-        // 유효성 검사와 DB 존재 여부 확인을 한 번에 처리
-        if (!JWTUtil.isValid(refreshToken, false) || !existsRefresh(refreshToken)) {
-            throw new RuntimeException("유효하지 않거나 DB에 존재하지 않는 refreshToken입니다.");
-        }
-
-        Long id = JWTUtil.getId(refreshToken);
-        String username = JWTUtil.getUsername(refreshToken);
-        String role = JWTUtil.getRole(refreshToken);
-
-        String newAccessToken = JWTUtil.createJWT(id, username, role, true);
-        String newRefreshToken = JWTUtil.createJWT(id, username, role, false);
-
-        // Redis에서 기존 토큰 삭제 후 신규 토큰 저장 (Rotate)
-        removeRefresh(refreshToken);
-        addRefresh(id, newRefreshToken);
+        // 공통 로직을 호출하여 토큰 재발급
+        JWTResponseDto newTokens = rotateTokens(refreshToken);
 
         // 기존 쿠키 제거
         Cookie refreshCookie = new Cookie("refreshToken", null);
@@ -64,15 +52,22 @@ public class JwtService {
         refreshCookie.setMaxAge(0); // 쿠키 즉시 만료
         response.addCookie(refreshCookie);
 
-        return new JWTResponseDto(newAccessToken, newRefreshToken);
+        return newTokens;
     }
 
     @Transactional
     public JWTResponseDto refreshRotate(RefreshRequestDto dto) {
-        String refreshToken = dto.getRefreshToken();
+        // 공통 로직을 호출하여 토큰 재발급
+        return rotateTokens(dto.getRefreshToken());
+    }
 
+    /**
+     * Refresh Token을 검증하고 새로운 Access/Refresh Token을 발급 (Rotate)하는 공통 메서드
+     */
+    private JWTResponseDto rotateTokens(String refreshToken) {
+        // 유효성 검사와 DB 존재 여부 확인을 한 번에 처리
         if (!JWTUtil.isValid(refreshToken, false) || Boolean.FALSE.equals(existsRefresh(refreshToken))) {
-            throw new RuntimeException("유효하지 않거나 DB에 존재하지 않는 refreshToken입니다.");
+            throw new InvalidRefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         Long id = JWTUtil.getId(refreshToken);

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/ErrorCode.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // 404 NOT_FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다."),
 
     // 409 CONFLICT
     USER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),
@@ -18,9 +19,13 @@ public enum ErrorCode {
     // 400 BAD_REQUEST
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 서로 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 DB에 존재하지 않는 refreshToken입니다."),
 
     // 403 FORBIDDEN
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 500 INTERNAL_SERVER_ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/GlobalControllerAdvice.java
@@ -1,11 +1,13 @@
 package io.github.junhyoung.nearbuy.global.exception;
 import io.github.junhyoung.nearbuy.global.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalControllerAdvice {
 
     // BusinessException을 상속받는 모든 커스텀 예외를 일괄 처리
@@ -23,5 +25,17 @@ public class GlobalControllerAdvice {
         return ResponseEntity
                 .status(ErrorCode.ACCESS_DENIED.getStatus())
                 .body(ApiResponse.error(ErrorCode.ACCESS_DENIED));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+        // 서버에 어떤 오류가 발생했는지 상세한 로그
+        log.error("[500] 서버 에러 메시지 : {}", e.getMessage(), e);
+
+        // 클라이언트에게는 상세한 오류 내용 대신 일반적인 서버 오류 메시지 전송
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode));
     }
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/InvalidRefreshTokenException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package io.github.junhyoung.nearbuy.global.exception.business;
+
+import io.github.junhyoung.nearbuy.global.exception.BusinessException;
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
+
+public class InvalidRefreshTokenException extends BusinessException {
+    public InvalidRefreshTokenException(ErrorCode errorCode) {
+        super(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/RefreshTokenNotFoundException.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/global/exception/business/RefreshTokenNotFoundException.java
@@ -1,0 +1,10 @@
+package io.github.junhyoung.nearbuy.global.exception.business;
+
+import io.github.junhyoung.nearbuy.global.exception.BusinessException;
+import io.github.junhyoung.nearbuy.global.exception.ErrorCode;
+
+public class RefreshTokenNotFoundException extends BusinessException {
+    public RefreshTokenNotFoundException(ErrorCode errorCode) {
+        super(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 📌 개요
- JwtService 내부에 중복으로 존재하던 토큰 재발급 로직을 private 메서드로 통합하여 코드의 재사용성과 가독성을 향상
- 기존에 RuntimeException으로 처리하던 Refresh Token 관련 오류들을 구체적인 커스텀 예외(InvalidRefreshTokenException, RefreshTokenNotFoundException)로 분리하여, 보다 명확하고 안정적인 예외 처리 체계를 구축

---
## 📋 작업 내용
- Exception: InvalidRefreshTokenException, RefreshTokenNotFoundException 커스텀 예외 클래스 추가
- GlobalControllerAdvice: 예측하지 못한 모든 예외를 처리하기 위한 handleException 메서드 추가
- JwtService: cookie2Header와 efreshRotate의 공통 로직을 rotateTokens 메서드로 추출하여 중복 제거
- ErrorCode: Refresh Token 관련 INVALID_REFRESH_TOKEN, REFRESH_TOKEN_NOT_FOUND 에러 코드 추가 / INTERNAL_SERVER_ERROR 서버 내부 에러 코드 추가

---
## 🔗 관련 이슈

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항