### PR TITLE
feat: QueryDSL 설정 추가 및 연관관계 편의 메서드 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
+    // 🔍 QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // 🔒 Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -52,4 +58,24 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// ===============================================================
+// QueryDSL 설정 추가
+// ===============================================================
+def generated = 'src/main/generated'
+
+// Q-Type 파일이 생성될 디렉토리 설정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// sourceSets에 generated 디렉토리 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// clean 태스크 실행 시 generated 디렉토리도 함께 삭제
+clean {
+    delete file(generated)
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/config/QuerydslConfig.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/config/QuerydslConfig.java
@@ -1,0 +1,23 @@
+package io.github.junhyoung.nearbuy.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * JPAQueryFactory를 Spring Bean으로 등록하여 프로젝트 전역에서 주입받아 사용할 수 있도록 설정
+     * EntityManager를 통해 JPA의 영속성 컨텍스트를 관리하며, 이를 기반으로 QueryDSL 쿼리를 생성
+     */
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
@@ -66,6 +66,7 @@ public class PostEntity extends BaseEntity {
 
     public void addPostImageEntity(PostImageEntity postImageEntity) {
         this.postImageEntityList.add(postImageEntity);
+        postImageEntity.setPost(this);
     }
 
     //== 내부 메서드 ==//

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostImageEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostImageEntity.java
@@ -25,9 +25,13 @@ public class PostImageEntity {
     private String imageUrl;
 
     @Builder
-    public PostImageEntity(PostEntity post, String imageUrl) {
-        this.post = post;
+    public PostImageEntity(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    //== 연관관계 편의 메서드 ==//
+    public void setPost(PostEntity post) {
+        this.post = post;
     }
 
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -55,7 +55,6 @@ public class PostService {
         // 3. 각 이미지 URL을 PostImage 엔티티로 만들어 PostEntity에 추가
         for (String imageUrl : imageUrls) {
             PostImageEntity postImageEntity = PostImageEntity.builder()
-                    .post(postEntity)
                     .imageUrl(imageUrl)
                     .build();
             postEntity.addPostImageEntity(postImageEntity);
@@ -107,7 +106,6 @@ public class PostService {
         List<String> newImageUrls = fileStore.storeFiles(addImages);
         for (String imageUrl : newImageUrls) {
             PostImageEntity newPostImage = PostImageEntity.builder()
-                    .post(postEntity)
                     .imageUrl(imageUrl)
                     .build();
             postEntity.addPostImageEntity(newPostImage);

--- a/src/test/java/io/github/junhyoung/nearbuy/NearbuyApplicationTests.java
+++ b/src/test/java/io/github/junhyoung/nearbuy/NearbuyApplicationTests.java
@@ -3,11 +3,68 @@ package io.github.junhyoung.nearbuy;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.github.junhyoung.nearbuy.user.entity.QUserEntity; // Q-Type 임포트
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import io.github.junhyoung.nearbuy.user.entity.enumerate.UserRoleType;
+import io.github.junhyoung.nearbuy.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
 @SpringBootTest
+@Transactional // 테스트 환경에서는 테스트 후 DB를 롤백시켜주는 어노테이션
 class NearbuyApplicationTests {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    UserRepository userRepository;
+
+    // QuerydslConfig에 의해 Bean으로 등록된 JPAQueryFactory를 주입받습니다.
+    @Autowired
+    JPAQueryFactory queryFactory;
 
     @Test
     void contextLoads() {
     }
 
+    @Test
+    @DisplayName("QueryDSL 설정 및 동작 테스트")
+    void querydslTest() {
+        // given: 테스트를 위한 데이터 준비
+        UserEntity newUser = UserEntity.builder()
+                .username("querydsl_user")
+                .password("password123!")
+                .email("test@test.com")
+                .nickname("쿼리dsl테스터")
+                .roleType(UserRoleType.USER)
+                .isLock(false)
+                .isSocial(false)
+                .build();
+        userRepository.save(newUser);
+
+        // 영속성 컨텍스트 초기화 (DB에 물리적으로 반영 후 컨텍스트를 비워 순수한 조회를 위함)
+        em.flush();
+        em.clear();
+
+        // when: QueryDSL을 사용하여 데이터 조회
+        // QUserEntity는 build 시점에 자동으로 생성된 클래스입니다.
+        QUserEntity qUserEntity = QUserEntity.userEntity;
+
+        UserEntity foundUser = queryFactory
+                .selectFrom(qUserEntity)
+                .where(qUserEntity.username.eq("querydsl_user"))
+                .fetchOne();
+
+        // then: 결과 검증
+        assertThat(foundUser).isNotNull();
+        assertThat(foundUser.getUsername()).isEqualTo("querydsl_user");
+        assertThat(foundUser.getId()).isEqualTo(newUser.getId());
+    }
 }


### PR DESCRIPTION
## 📌 개요
QueryDSL 설정 추가 및 연관관계 편의 메서드 리팩토링

---
## 📋 작업 내용
- config/QuerydslConfig.java: JPAQueryFactory를 빈(Bean)으로 등록하여 프로젝트 전역에서 QueryDSL을 사용할 수 있도록 설정 파일을 추가
- build.gradle: QueryDSL 의존성 및 Q-Type 자동 생성/관리 설정을 추가
- PostEntity, PostImageEntity: 연관관계 편의 메서드를 개선하여 양방향 관계 설정 로직을 캡슐화
- PostService: 엔티티의 개선된 편의 메서드를 사용하도록 이미지 생성 로직을 수정
- NearbuyApplicationTests: QueryDSL 설정 및 실제 동작을 검증하기 위한 단위 테스트 코드를 추가

---
## 🔗 관련 이슈
Closes #22

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항