### PR TITLE
feat: QueryDSL을 이용한 게시글 동적 검색 기능 구현

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -3,6 +3,7 @@ package io.github.junhyoung.nearbuy.post.controller;
 import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
 import io.github.junhyoung.nearbuy.global.common.ApiResponse;
 import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.request.PostSearchCond;
 import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.response.MyPostResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
@@ -43,6 +44,13 @@ public class PostController {
     @GetMapping
     public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> readPostApi(Pageable pageable) {
         Slice<PostResponseDto> postResponseDtos = postService.readPosts(pageable);
+        return ResponseEntity.ok(ApiResponse.success(postResponseDtos));
+    }
+
+    // 게시글 조건 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> searchPostsApi(@ModelAttribute PostSearchCond cond, Pageable pageable) {
+        Slice<PostResponseDto> postResponseDtos = postService.searchPosts(cond, pageable);
         return ResponseEntity.ok(ApiResponse.success(postResponseDtos));
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostSearchCond.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/request/PostSearchCond.java
@@ -1,0 +1,22 @@
+package io.github.junhyoung.nearbuy.post.dto.request;
+
+import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostSearchCond {
+
+    private String title;
+
+    private PostStatus postStatus;
+
+    private ProductCategory productCategory;
+
+    private Integer minPrice;
+
+    private Integer maxPrice;
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<PostEntity, Long> {
+public interface PostRepository extends JpaRepository<PostEntity, Long>, PostRepositoryCustom {
 
     @Query(value = "SELECT p FROM PostEntity p JOIN FETCH p.userEntity u")
     Slice<PostEntity> findAllWithUser(Pageable pageable);

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,10 @@
+package io.github.junhyoung.nearbuy.post.repository;
+
+import io.github.junhyoung.nearbuy.post.dto.request.PostSearchCond;
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface PostRepositoryCustom {
+    Slice<PostEntity> search(PostSearchCond cond, Pageable pageable);
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepositoryImpl.java
@@ -1,0 +1,78 @@
+package io.github.junhyoung.nearbuy.post.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.github.junhyoung.nearbuy.post.dto.request.PostSearchCond;
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.entity.QPostEntity;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.PostStatus;
+import io.github.junhyoung.nearbuy.post.entity.enumerate.ProductCategory;
+import io.github.junhyoung.nearbuy.user.entity.QUserEntity;
+import io.netty.util.internal.StringUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static io.github.junhyoung.nearbuy.post.entity.QPostEntity.*;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<PostEntity> search(PostSearchCond cond, Pageable pageable) {
+        List<PostEntity> content = queryFactory
+                .selectFrom(postEntity)
+                .join(postEntity.userEntity, QUserEntity.userEntity).fetchJoin()
+                .where(
+                        titleContains(cond.getTitle()),
+                        statusEq(cond.getPostStatus()),
+                        categoryEq(cond.getProductCategory()),
+                        priceBetween(cond.getMinPrice(), cond.getMaxPrice())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(postEntity.createdAt.desc())
+                .fetch();
+
+        boolean hasNext = false;
+
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    private BooleanExpression titleContains(String title) {
+        return StringUtils.hasText(title) ? postEntity.title.contains(title) : null;
+    }
+
+    private BooleanExpression statusEq(PostStatus postStatus) {
+        return postStatus != null ? postEntity.postStatus.eq(postStatus) : null;
+    }
+
+    private BooleanExpression categoryEq(ProductCategory productCategory) {
+        return productCategory != null ? postEntity.productCategory.eq(productCategory) : null;
+    }
+
+    private BooleanExpression priceBetween(Integer minPrice, Integer maxPrice) {
+        if (minPrice == null && maxPrice == null) {
+            return null;
+        }
+        if (minPrice != null && maxPrice != null) {
+            return postEntity.price.between(minPrice, maxPrice);
+        }
+        if (minPrice != null) {
+            return postEntity.price.goe(minPrice); // Greater than or Equal to (>=)
+        }
+        return postEntity.price.loe(maxPrice); // Less than or Equal to (<=)
+    }
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -4,6 +4,7 @@ import io.github.junhyoung.nearbuy.global.exception.business.PostNotFoundExcepti
 import io.github.junhyoung.nearbuy.global.exception.business.UserNotFoundException;
 import io.github.junhyoung.nearbuy.global.util.FileStore;
 import io.github.junhyoung.nearbuy.post.dto.request.PostCreateRequestDto;
+import io.github.junhyoung.nearbuy.post.dto.request.PostSearchCond;
 import io.github.junhyoung.nearbuy.post.dto.request.PostUpdateRequestDto;
 import io.github.junhyoung.nearbuy.post.dto.response.MyPostResponseDto;
 import io.github.junhyoung.nearbuy.post.dto.response.PostDetailResponseDto;
@@ -66,6 +67,12 @@ public class PostService {
     // 게시글 전체 조회
     public Slice<PostResponseDto> readPosts(Pageable pageable) {
         Slice<PostEntity> posts = postRepository.findAllWithUser(pageable);
+        return posts.map(PostResponseDto::from);
+    }
+
+    // 게시글 조건 검색
+    public Slice<PostResponseDto> searchPosts(PostSearchCond cond, Pageable pageable) {
+        Slice<PostEntity> posts = postRepository.search(cond, pageable);
         return posts.map(PostResponseDto::from);
     }
 


### PR DESCRIPTION
## 📌 개요
- 사용자가 제목, 판매 상태, 카테고리, 가격 범위를 기준으로 게시글을 동적으로 검색할 수 있는 기능을 추가
- QueryDSL의 BooleanExpression과 where절 다중 파라미터를 활용하여 재사용 가능하고 가독성 높은 동적 쿼리를 작성

---
## 📋 작업 내용
- dto: 검색 조건을 담는 PostSearchCond DTO 클래스 추가
- repository: QueryDSL을 위한 PostRepositoryCustom, PostRepositoryImpl 추가
- PostController: 게시글을 조건부로 조회하는 searchPostsApi GET 메서드 추가
- PostService: searchPosts 비즈니스 로직 추가
- PostRepository: PostRepositoryCustom을 상속받아 기능 통합

---
## 🔗 관련 이슈

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항