### PR TITLE
Feature/post

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/FavoriteController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/FavoriteController.java
@@ -1,0 +1,49 @@
+package io.github.junhyoung.nearbuy.post.controller;
+
+import io.github.junhyoung.nearbuy.auth.web.dto.UserPrincipal;
+import io.github.junhyoung.nearbuy.global.common.ApiResponse;
+import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
+import io.github.junhyoung.nearbuy.post.service.FavoriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/favorites")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    // 즐겨찾기 추가/삭제 (토글)
+    @PostMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> toggleFavorite(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        boolean isFavorited = favoriteService.toggleFavorite(userPrincipal.id(), postId);
+        return ResponseEntity.ok(ApiResponse.success(Map.of("isFavorited", isFavorited)));
+    }
+
+    // 특정 게시글의 즐겨찾기 상태 확인
+    @GetMapping("/{postId}/status")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkFavoriteStatus(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        boolean isFavorited = favoriteService.checkFavoriteStatus(userPrincipal.id(), postId);
+        return ResponseEntity.ok(ApiResponse.success(Map.of("isFavorited", isFavorited)));
+    }
+
+    // 나의 관심 목록 조회
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> getMyFavorites(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            Pageable pageable) {
+        Slice<PostResponseDto> myFavoritePosts = favoriteService.getMyFavoritePosts(userPrincipal.id(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(myFavoritePosts));
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -48,7 +48,7 @@ public class PostController {
     }
 
     // 게시글 조건 조회
-    @GetMapping
+    @GetMapping("/search")
     public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> searchPostsApi(@ModelAttribute PostSearchCond cond, Pageable pageable) {
         Slice<PostResponseDto> postResponseDtos = postService.searchPosts(cond, pageable);
         return ResponseEntity.ok(ApiResponse.success(postResponseDtos));
@@ -65,8 +65,10 @@ public class PostController {
 
     // 게시글 상세 조회
     @GetMapping("{postId}")
-    public ResponseEntity<ApiResponse<PostDetailResponseDto>> readPostDetailApi(@PathVariable Long postId) {
-        PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(postId);
+    public ResponseEntity<ApiResponse<PostDetailResponseDto>> readPostDetailApi(
+                                @AuthenticationPrincipal UserPrincipal userPrincipal,
+                                @PathVariable Long postId) {
+        PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(userPrincipal.id(), postId);
         return ResponseEntity.ok(ApiResponse.success(postDetailResponseDto));
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -68,7 +68,8 @@ public class PostController {
     public ResponseEntity<ApiResponse<PostDetailResponseDto>> readPostDetailApi(
                                 @AuthenticationPrincipal UserPrincipal userPrincipal,
                                 @PathVariable Long postId) {
-        PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(userPrincipal.id(), postId);
+        Long userId = (userPrincipal != null) ? userPrincipal.id() : null;
+        PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(userId, postId);
         return ResponseEntity.ok(ApiResponse.success(postDetailResponseDto));
     }
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
@@ -36,7 +36,9 @@ public class PostDetailResponseDto {
 
     private List<PostImageResponseDto> postImages = new ArrayList<>();
 
-    private PostDetailResponseDto(PostEntity postEntity) {
+    private boolean isFavorited;
+
+    private PostDetailResponseDto(PostEntity postEntity, boolean isFavorited) {
         this.postId = postEntity.getId();
         this.authorId = postEntity.getUserEntity().getId();
         this.authorNickname = postEntity.getUserEntity().getNickname();
@@ -49,10 +51,11 @@ public class PostDetailResponseDto {
         this.postImages = postEntity.getPostImageEntityList().stream()
                 .map(PostImageResponseDto::new)
                 .collect(Collectors.toList());
+        this.isFavorited = isFavorited;
     }
 
-    public static PostDetailResponseDto from(PostEntity postEntity) {
-        return new PostDetailResponseDto(postEntity);
+    public static PostDetailResponseDto from(PostEntity postEntity, boolean isFavorited) {
+        return new PostDetailResponseDto(postEntity, isFavorited);
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/FavoriteEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/FavoriteEntity.java
@@ -1,0 +1,33 @@
+package io.github.junhyoung.nearbuy.post.entity;
+
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "favorite")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private PostEntity postEntity;
+
+    @Builder
+    public FavoriteEntity(UserEntity userEntity, PostEntity postEntity) {
+        this.userEntity = userEntity;
+        this.postEntity = postEntity;
+    }
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Table(name = "post")
@@ -71,21 +72,11 @@ public class PostEntity extends BaseEntity {
 
     //== 내부 메서드 ==//
     public void updatePostDetail(PostUpdateRequestDto dto) {
-        if (dto.getTitle() != null) {
-            this.title = dto.getTitle();
-        }
-        if (dto.getContents() != null) {
-            this.contents = dto.getContents();
-        }
-        if (dto.getPostStatus() != null) {
-            this.postStatus = dto.getPostStatus();
-        }
-        if (dto.getPrice() != null) {
-            this.price = dto.getPrice();
-        }
-        if (dto.getProductCategory() != null) {
-            this.productCategory = dto.getProductCategory();
-        }
+        Optional.ofNullable(dto.getTitle()).ifPresent(newTitle -> this.title = newTitle);
+        Optional.ofNullable(dto.getContents()).ifPresent(newContents -> this.contents = newContents);
+        Optional.ofNullable(dto.getPostStatus()).ifPresent(newStatus -> this.postStatus = newStatus);
+        Optional.ofNullable(dto.getPrice()).ifPresent(newPrice -> this.price = newPrice);
+        Optional.ofNullable(dto.getProductCategory()).ifPresent(newCategory -> this.productCategory = newCategory);
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/FavoriteRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/FavoriteRepository.java
@@ -1,0 +1,24 @@
+package io.github.junhyoung.nearbuy.post.repository;
+
+import io.github.junhyoung.nearbuy.post.entity.FavoriteEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+
+public interface FavoriteRepository extends JpaRepository<FavoriteEntity, Long> {
+
+    Optional<FavoriteEntity> findByUserEntity_IdAndPostEntity_Id(Long userId, Long postId);
+
+    @Query(value = "SELECT f FROM FavoriteEntity f " +
+            "JOIN FETCH f.postEntity p " +
+            "JOIN FETCH p.userEntity u " +
+            "WHERE f.userEntity.id = :userId " +
+            "ORDER BY p.createdAt DESC")
+    Slice<FavoriteEntity> findFavoritesByUserId(@Param(value = "userId") Long userId, Pageable pageable);
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long>, PostRepositoryCustom {
 
@@ -20,5 +21,11 @@ public interface PostRepository extends JpaRepository<PostEntity, Long>, PostRep
             "LEFT JOIN FETCH p.userEntity u " +
             "WHERE p.userEntity.id=:userId")
     Slice<PostEntity> findMyPosts(@Param(value="userId") Long userId, Pageable pageable);
+
+    @Query("SELECT p FROM PostEntity p " +
+            "JOIN FETCH p.userEntity " +
+            "LEFT JOIN FETCH p.postImageEntityList " +
+            "WHERE p.id = :postId")
+    Optional<PostEntity> findPostWithDetailsById(@Param("postId") Long postId);
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/FavoriteService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/FavoriteService.java
@@ -1,0 +1,71 @@
+package io.github.junhyoung.nearbuy.post.service;
+
+import io.github.junhyoung.nearbuy.global.exception.business.PostNotFoundException;
+import io.github.junhyoung.nearbuy.global.exception.business.UserNotFoundException;
+import io.github.junhyoung.nearbuy.post.dto.response.PostResponseDto;
+import io.github.junhyoung.nearbuy.post.entity.FavoriteEntity;
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.repository.FavoriteRepository;
+import io.github.junhyoung.nearbuy.post.repository.PostRepository;
+import io.github.junhyoung.nearbuy.user.entity.UserEntity;
+import io.github.junhyoung.nearbuy.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    // 게시글 즐겨찾기 추가/삭제 (토글)
+    @Transactional
+    public boolean toggleFavorite(Long userId, Long postId) {
+        Optional<FavoriteEntity> favoriteOptional = favoriteRepository.findByUserEntity_IdAndPostEntity_Id(userId, postId);
+
+        if (favoriteOptional.isPresent()) {
+            // 이미 즐겨찾기 상태이면 삭제
+            favoriteRepository.delete(favoriteOptional.get());
+            return false;
+        } else {
+            // 즐겨찾기가 아니면 추가
+            UserEntity user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+            PostEntity post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+
+            FavoriteEntity favorite = FavoriteEntity.builder()
+                    .userEntity(user)
+                    .postEntity(post)
+                    .build();
+
+            favoriteRepository.save(favorite);
+            return true;
+        }
+    }
+
+
+    // 특정 게시글의 즐겨찾기 상태 조회
+    @Transactional(readOnly = true)
+    public boolean checkFavoriteStatus(Long userId, Long postId) {
+        return favoriteRepository.findByUserEntity_IdAndPostEntity_Id(userId, postId).isPresent();
+    }
+
+    // 나의 관심 목록 조회
+    @Transactional(readOnly = true)
+    public Slice<PostResponseDto> getMyFavoritePosts(Long userId, Pageable pageable) {
+        Slice<FavoriteEntity> favorites = favoriteRepository.findFavoritesByUserId(userId, pageable);
+        // Favorite 슬라이스를 PostResponseDto 슬라이스로 변환
+        return favorites.map(favorite -> PostResponseDto.from(favorite.getPostEntity()));
+    }
+
+
+}

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostService.java
@@ -83,8 +83,8 @@ public class PostService {
     }
 
     // 게시글 세부 조회
-    public PostDetailResponseDto readPostDetail(Long postId, Long userId) {
-        PostEntity postEntity = postRepository.findById(postId)
+    public PostDetailResponseDto readPostDetail(Long userId, Long postId) {
+        PostEntity postEntity = postRepository.findPostWithDetailsById(postId)
                 .orElseThrow(PostNotFoundException::new);
 
         boolean isFavorited = false;


### PR DESCRIPTION
## 📌 개요
- 사용자가 게시글을 관심 목록에 추가/삭제하고, 여러 조건(제목, 판매상태, 카테고리, 가격범위)으로 동적 검색을 수행할 수 있는 기능을 구현
- 상세 조회 시, 넘겨주는 파라미터의 순서가 잘못 되어있었음 (postId, userId) -> (userId, postId)로 변경
- 상세 조회 시, favorite N+1 문제 발생해서 post 조회 시에 fetch join 적용

---
## 📋 작업 내용
[ADD]
- Entity: Favorite 엔티티를 추가하여 사용자와 게시글 간의 다대다 관계를 매핑
- Repository: FavoriteRepository를 추가하고, PostRepositoryCustom/Impl을 구현하여 QueryDSL을 이용한 동적 검색 로직을 작성
- Service: FavoriteService를 추가하여 관심(좋아요) 관련 비즈니스 로직을 처리
- Controller: FavoriteController를 추가하여 관심 기능 관련 API 엔드포인트를 제공
- DTO: 동적 검색 조건을 담기 위한 PostSearchCond DTO를 추가

[MODIFY]
- PostService: 게시글 상세 조회 시, 로그인한 사용자의 '좋아요' 여부를 함께 반환하도록 
eadPostDetail 메서드를 수정
- PostController: 상세 조회 API가 @AuthenticationPrincipal을 통해 현재 사용자 정보를 받도록 수정하고, 동적 검색을 위한 searchPostsApi 엔드포인트를 추가
- SecurityConfig: /favorites/** 경로에 대한 접근은 인증된 사용자만 가능하도록 인가 규칙을 업데이트

---
## 🔗 관련 이슈

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항