### PR TITLE
refactor: 게시글 조회 및 정렬 로직 개선 및 버그 수정

### DIFF
--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/FavoriteController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/FavoriteController.java
@@ -22,25 +22,16 @@ public class FavoriteController {
 
     // 즐겨찾기 추가/삭제 (토글)
     @PostMapping("/{postId}")
-    public ResponseEntity<ApiResponse<Map<String, Boolean>>> toggleFavorite(
-            @PathVariable Long postId,
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> toggleFavoriteApi(
+            @PathVariable("postId") Long postId,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         boolean isFavorited = favoriteService.toggleFavorite(userPrincipal.id(), postId);
         return ResponseEntity.ok(ApiResponse.success(Map.of("isFavorited", isFavorited)));
     }
 
-    // 특정 게시글의 즐겨찾기 상태 확인
-    @GetMapping("/{postId}/status")
-    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkFavoriteStatus(
-            @PathVariable Long postId,
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        boolean isFavorited = favoriteService.checkFavoriteStatus(userPrincipal.id(), postId);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("isFavorited", isFavorited)));
-    }
-
     // 나의 관심 목록 조회
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> getMyFavorites(
+    public ResponseEntity<ApiResponse<Slice<PostResponseDto>>> getMyFavoritesApi(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             Pageable pageable) {
         Slice<PostResponseDto> myFavoritePosts = favoriteService.getMyFavoritePosts(userPrincipal.id(), pageable);

--- a/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/controller/PostController.java
@@ -67,7 +67,7 @@ public class PostController {
     @GetMapping("{postId}")
     public ResponseEntity<ApiResponse<PostDetailResponseDto>> readPostDetailApi(
                                 @AuthenticationPrincipal UserPrincipal userPrincipal,
-                                @PathVariable Long postId) {
+                                @PathVariable("postId") Long postId) {
         Long userId = (userPrincipal != null) ? userPrincipal.id() : null;
         PostDetailResponseDto postDetailResponseDto = postService.readPostDetail(userId, postId);
         return ResponseEntity.ok(ApiResponse.success(postDetailResponseDto));
@@ -76,7 +76,7 @@ public class PostController {
     // 게시글 수정
     @PatchMapping(value = "/{postId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ApiResponse<Void>> updatePostApi(
-            @PathVariable Long postId,
+            @PathVariable("postId") Long postId,
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestPart("dto") PostUpdateRequestDto dto,
             @RequestPart(value = "addImages", required = false) List<MultipartFile> addImages) throws IOException {
@@ -87,7 +87,7 @@ public class PostController {
 
     // 게시글 삭제
     @DeleteMapping("{postId}")
-    public ResponseEntity<ApiResponse<Void>> deletePostApi(@PathVariable Long postId,
+    public ResponseEntity<ApiResponse<Void>> deletePostApi(@PathVariable("postId") Long postId,
                                                            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         postService.deletePost(postId, userPrincipal.id());
         return ResponseEntity.ok(ApiResponse.success());

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostDetailResponseDto.java
@@ -38,7 +38,9 @@ public class PostDetailResponseDto {
 
     private boolean isFavorited;
 
-    private PostDetailResponseDto(PostEntity postEntity, boolean isFavorited) {
+    private Long viewCount;
+
+    private PostDetailResponseDto(PostEntity postEntity, boolean isFavorited, Long viewCount) {
         this.postId = postEntity.getId();
         this.authorId = postEntity.getUserEntity().getId();
         this.authorNickname = postEntity.getUserEntity().getNickname();
@@ -52,10 +54,11 @@ public class PostDetailResponseDto {
                 .map(PostImageResponseDto::new)
                 .collect(Collectors.toList());
         this.isFavorited = isFavorited;
+        this.viewCount = viewCount;
     }
 
-    public static PostDetailResponseDto from(PostEntity postEntity, boolean isFavorited) {
-        return new PostDetailResponseDto(postEntity, isFavorited);
+    public static PostDetailResponseDto from(PostEntity postEntity, boolean isFavorited, Long viewCount) {
+        return new PostDetailResponseDto(postEntity, isFavorited, viewCount);
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
@@ -31,7 +31,9 @@ public class PostResponseDto {
 
     private PostStatus status;
 
-    private PostResponseDto(PostEntity postEntity) {
+    private Long viewCount;
+
+    private PostResponseDto(PostEntity postEntity, Long viewCount) {
         this.postId = postEntity.getId();
         this.authorNickname = postEntity.getUserEntity().getNickname();
         this.title = postEntity.getTitle();
@@ -45,8 +47,12 @@ public class PostResponseDto {
                 .orElse(null);
     }
 
+    public static PostResponseDto from(PostEntity postEntity, Long viewCount) {
+        return new PostResponseDto(postEntity, viewCount);
+    }
+
     public static PostResponseDto from(PostEntity postEntity) {
-        return new PostResponseDto(postEntity);
+        return new PostResponseDto(postEntity, postEntity.getViewCount());
     }
 
 

--- a/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/dto/response/PostResponseDto.java
@@ -45,6 +45,7 @@ public class PostResponseDto {
                 .findFirst()
                 .map(PostImageResponseDto::new)
                 .orElse(null);
+        this.viewCount = viewCount;
     }
 
     public static PostResponseDto from(PostEntity postEntity, Long viewCount) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/entity/PostEntity.java
@@ -49,14 +49,17 @@ public class PostEntity extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostImageEntity> postImageEntityList = new ArrayList<>();
 
+    private Long viewCount;
+
     @Builder
-    public PostEntity(UserEntity userEntity, String title, String contents, Integer price, ProductCategory productCategory, PostStatus postStatus, String imageUrl) {
+    public PostEntity(UserEntity userEntity, String title, String contents, Integer price, ProductCategory productCategory, PostStatus postStatus) {
         this.userEntity = userEntity;
         this.title = title;
         this.contents = contents;
         this.price = price;
         this.productCategory = productCategory;
         this.postStatus = postStatus;
+        this.viewCount = 0L;
     }
 
     //== 연관관계 편의 메서드 ==//
@@ -77,6 +80,10 @@ public class PostEntity extends BaseEntity {
         Optional.ofNullable(dto.getPostStatus()).ifPresent(newStatus -> this.postStatus = newStatus);
         Optional.ofNullable(dto.getPrice()).ifPresent(newPrice -> this.price = newPrice);
         Optional.ofNullable(dto.getProductCategory()).ifPresent(newCategory -> this.productCategory = newCategory);
+    }
+
+    public void updateViewCount(Long viewCount) {
+        this.viewCount = viewCount;
     }
 
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/repository/PostRepository.java
@@ -28,4 +28,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Long>, PostRep
             "WHERE p.id = :postId")
     Optional<PostEntity> findPostWithDetailsById(@Param("postId") Long postId);
 
+    @Query("SELECT p FROM PostEntity p JOIN FETCH p.userEntity LEFT JOIN FETCH p.postImageEntityList WHERE p.id IN :ids")
+    List<PostEntity> findAllByIdIn(@Param("ids") List<Long> ids);
+
 }

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/FavoriteService.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/FavoriteService.java
@@ -52,13 +52,6 @@ public class FavoriteService {
         }
     }
 
-
-    // 특정 게시글의 즐겨찾기 상태 조회
-    @Transactional(readOnly = true)
-    public boolean checkFavoriteStatus(Long userId, Long postId) {
-        return favoriteRepository.findByUserEntity_IdAndPostEntity_Id(userId, postId).isPresent();
-    }
-
     // 나의 관심 목록 조회
     @Transactional(readOnly = true)
     public Slice<PostResponseDto> getMyFavoritePosts(Long userId, Pageable pageable) {

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostScheduler.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostScheduler.java
@@ -23,8 +23,8 @@ public class PostScheduler {
     private final PostRepository postRepository;
     private static final String VIEW_COUNT_KEY = "post:view_scores";
 
-    // 10분마다 실행 (cron = "0 */10 * * * *")
-    @Scheduled(cron = "0 */10 * * * *")
+    // 5분마다 실행 (cron = "0 */5 * * * *")
+    @Scheduled(cron = "0 */5 * * * *")
     @Transactional
     public void syncViewCountsToDb() {
         log.info("조회수 동기화 스케줄러 시작");

--- a/src/main/java/io/github/junhyoung/nearbuy/post/service/PostScheduler.java
+++ b/src/main/java/io/github/junhyoung/nearbuy/post/service/PostScheduler.java
@@ -1,0 +1,53 @@
+package io.github.junhyoung.nearbuy.post.service;
+
+import io.github.junhyoung.nearbuy.post.entity.PostEntity;
+import io.github.junhyoung.nearbuy.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final PostRepository postRepository;
+    private static final String VIEW_COUNT_KEY = "post:view_scores";
+
+    // 10분마다 실행 (cron = "0 */10 * * * *")
+    @Scheduled(cron = "0 */10 * * * *")
+    @Transactional
+    public void syncViewCountsToDb() {
+        log.info("조회수 동기화 스케줄러 시작");
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+
+        // Redis에 있는 모든 조회수 정보를 가져옴
+        Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOps.rangeWithScores(VIEW_COUNT_KEY, 0, -1);
+
+        if (typedTuples == null || typedTuples.isEmpty()) {
+            log.info("업데이트할 조회수 정보가 없습니다.");
+            return;
+        }
+
+        // DB 업데이트
+        typedTuples.forEach(tuple -> {
+            Long postId = Long.valueOf(tuple.getValue());
+            Long viewCount = tuple.getScore().longValue();
+
+            postRepository.findById(postId).ifPresent(post -> {
+                post.updateViewCount(viewCount);
+            });
+        });
+
+        log.info("{}개의 게시물 조회수를 DB에 동기화했습니다.", typedTuples.size());
+    }
+}


### PR DESCRIPTION
## 📌 개요
게시글 목록 조회 시 발생하던 필터링 및 정렬 관련 버그를 수정하고, 실시간 조회수가 올바르게 반영되도록 전체 로직을 개선합니다.

---
## 📋 작업 내용
1. `PostRepositoryImpl` 동적 정렬 구현
   - 기존에 `createdAt`으로 고정되었던 정렬 로직을 `Pageable` 객체의 Sort 정보를 동적으로 처리하도록 수정했습니다.
   - 이제 `viewCount`와 `createdAt` 기준으로 정상적인 데이터베이스 정렬이 가능합니다.

2. `PostService` 로직 단순화 및 리팩토링
   - `viewCount` 정렬을 위해 분기하던 불필요한 로직과 `searchPostsByViewCount` 메서드를 제거했습니다.
   - 모든 검색/조회 요청이 `PostRepository.search`를 통하도록 로직을 통합하여 일관성을 확보하고 코드를 단순화했습니다.
   - 게시글 목록 조회 시 DB 값이 아닌 Redis의 실시간 조회수가 DTO에 올바르게 반영되도록 수정했습니다.

3. 조회수 동기화 주기 변경
   - Redis의 조회수 데이터를 DB에 동기화하는 스케줄러(`PostScheduler`)의 실행 주기를 10분에서 5분으로 단축했습니다.

4. 버그 수정 및 코드 개선
   - `PostResponseDto` 생성자에서 `viewCount` 값이 누락되던 버그를 수정했습니다.
   - `PostController`와 `FavoriteController`의 `@PathVariable`에 `name` 속성을 명시하여 가독성과 안정성을 향상시켰습니다.
   - `FavoriteController`에서 사용되지 않는 `checkFavoriteStatus` 관련 API 및 서비스 로직을 제거했습니다.


---
## 🔗 관련 이슈
Closes #27

---
## ✅ PR 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---
## 💬 기타 사항
- 이번 리팩토링으로 '조회순' 정렬은 스케줄러에 의해 DB에 반영된 값을 기준으로 동작합니다. 이로 인해 정렬 순서의 데이터 정합성은 보장되나, 조회수가 최대 5분 지연되어 표시될 수 있습니다.

